### PR TITLE
Implement offline mode in codexRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ function MyComponent() {
 }
 ```
 
+## Offline Mode
+Set the `OFFLINE_MODE` environment variable to `true` to mock network requests with `codexRequest`. //(document new offline mode)
+
 ## License
 
 ISC

--- a/lib/api.js
+++ b/lib/api.js
@@ -148,15 +148,17 @@ async function executeAxiosRequest(axiosCall, unauthorizedBehavior, mockResponse
  * @returns {Promise} Request result or mock response
  */
 async function codexRequest(requestFn, mockResponse) {
-  // Execute the actual request function
-  // In a future implementation, this could check for offline/Codex mode
-  // and return mockResponse when appropriate
+  console.log(`codexRequest is running with ${process.env.OFFLINE_MODE}`); //(log offline mode state)
   try {
-    return await requestFn();
+    if (process.env.OFFLINE_MODE === `true`) {
+      console.log(`codexRequest is returning ${JSON.stringify(mockResponse)}`); //(return mock response when offline)
+      return mockResponse; //(provide mock network result)
+    }
+    const res = await requestFn();
+    console.log(`codexRequest is returning ${JSON.stringify(res)}`); //(return actual response)
+    return res; //(pass through real network result)
   } catch (err) {
-    // Re-throw the error to maintain existing error handling behavior
-    // This ensures the calling code receives the actual error for proper handling
-    throw err;
+    throw err; //(rethrow request errors for caller handling)
   }
 }
 


### PR DESCRIPTION
## Summary
- implement `OFFLINE_MODE` env variable in `codexRequest`
- document offline mode usage in README

## Testing
- `npm test` *(fails: Invalid hook call)*

------
https://chatgpt.com/codex/tasks/task_b_6845797430dc832289114dbb6af50efb