### PR TITLE
Add inline comments to API and index exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@
 // Import all hooks, utilities, and API functions from the consolidated hooks module
 // The hooks module acts as an aggregator, pulling together functionality from multiple internal modules
 const {
-  useAsyncAction, useDropdownData, createDropdownListHook, useDropdownToggle,
-  useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect,
-  showToast, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient
+  useAsyncAction, useDropdownData, createDropdownListHook, useDropdownToggle, //(grab hook utilities)
+  useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect, //(grab UI helpers)
+  showToast, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient //(grab API utilities)
 } = require('./lib/hooks'); // aggregated exports from internal modules
 
 /**
@@ -31,7 +31,7 @@ const {
  * 3. Provides better tooling support for IDEs and documentation generators
  * 4. Makes it clear to maintainers what the intended public surface is
  */
-module.exports = {
+module.exports = { // expose library functions
   // Core async functionality hooks
   useAsyncAction,        // Primary hook for async operations with loading states
   useToastAction,        // Combination of async action with automatic toast notifications
@@ -60,4 +60,4 @@ module.exports = {
   queryClient,           // Pre-configured React Query client instance
   formatAxiosError,      // Error normalization for consistent error handling
   axiosClient            // Pre-configured axios instance with sensible defaults
-};
+}; // export object

--- a/lib/api.js
+++ b/lib/api.js
@@ -64,7 +64,7 @@ const axiosClient = axios.create({
  */
 function buildRequestConfig(url, method, data) {
   return { url, method, data };
-}
+} //(end formatAxiosError)
 
 /**
  * Helper function for creating mock responses based on URL patterns
@@ -115,18 +115,18 @@ function handle401Error(error, behavior) {
  * @param {*} mockResponse - Mock response for offline/Codex mode
  * @returns {Promise} Response data or formatted error
  */
-async function executeAxiosRequest(axiosCall, unauthorizedBehavior, mockResponse) {
-  try {
-    const response = await codexRequest(axiosCall, mockResponse);
-    return response;
-  } catch (err) {
+async function executeAxiosRequest(axiosCall, unauthorizedBehavior, mockResponse) { //(standardized axios wrapper)
+  try { //(attempt request)
+    const response = await codexRequest(axiosCall, mockResponse); //(call axios with codex wrapper)
+    return response; //(return full axios response)
+  } catch (err) { //(catch request errors)
     // Handle 401 errors based on specified behavior
     if (handle401Error(err, unauthorizedBehavior)) {
       return { data: null }; // Return null data structure for consistency
     }
-    throw formatAxiosError(err);
+    throw formatAxiosError(err); //(rethrow normalized error)
   }
-}
+} //(end executeAxiosRequest)
 
 /**
  * Codex request wrapper for development/offline mode support
@@ -147,7 +147,7 @@ async function executeAxiosRequest(axiosCall, unauthorizedBehavior, mockResponse
  * @param {Object} mockResponse - Mock response to return in offline mode
  * @returns {Promise} Request result or mock response
  */
-async function codexRequest(requestFn, mockResponse) {
+async function codexRequest(requestFn, mockResponse) { //(handle codex offline logic)
   console.log(`codexRequest is running with ${process.env.OFFLINE_MODE}`); //(log offline mode state)
   try {
     if (process.env.OFFLINE_MODE === `true`) {
@@ -160,14 +160,14 @@ async function codexRequest(requestFn, mockResponse) {
   } catch (err) {
     throw err; //(rethrow request errors for caller handling)
   }
-}
+} //(end codexRequest)
 
 /**
  * Normalize axios error into a standard Error object
  * @param {unknown} err - The error to format
  * @returns {Error} Formatted error object
  */
-function formatAxiosError(err) {
+function formatAxiosError(err) { //(normalize axios error)
   console.log(`formatAxiosError is running with ${err}`);
   try {
     if (axios.isAxiosError(err)) {
@@ -206,21 +206,21 @@ function formatAxiosError(err) {
  * @param {unknown} data - Request body data
  * @returns {Promise} Response data
  */
-async function apiRequest(url, method = 'POST', data) {
-  console.log(`apiRequest is running with ${method} ${url}`);
+async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
+  console.log(`apiRequest is running with ${method} ${url}`); //(log request info)
   try {
     const response = await codexRequest(
-      () => axiosClient.request({ url, method, data }),
-      { data: { message: 'Mocked in Codex' } }
+      () => axiosClient.request({ url, method, data }), //(perform axios call)
+      { data: { message: 'Mocked in Codex' } } //(mock offline response)
     );
-    const result = response.data;
+    const result = response.data; //(extract data payload)
     console.log(`apiRequest is returning ${JSON.stringify(result)}`);
     return result;
-  } catch (err) {
+  } catch (err) { //(handle axios errors)
     console.error('apiRequest error:', err);
-    throw formatAxiosError(err);
+    throw formatAxiosError(err); //(rethrow normalized error)
   }
-}
+} //(end apiRequest)
 
 /**
  * Create a React Query function that handles 401 errors gracefully
@@ -228,24 +228,24 @@ async function apiRequest(url, method = 'POST', data) {
  * @param {string} options.on401 - How to handle 401 errors ('returnNull' or 'throw')
  * @returns {Function} QueryFunction for React Query
  */
-function getQueryFn(options) {
-  const { on401: unauthorizedBehavior } = options;
+function getQueryFn(options) { //(factory for query functions)
+  const { on401: unauthorizedBehavior } = options; //(extract 401 strategy)
   
-  return async ({ queryKey }) => {
-    console.log(`getQueryFn inner is running with ${queryKey[0]}`);
+  return async ({ queryKey }) => { //(returned QueryFunction)
+    console.log(`getQueryFn inner is running with ${queryKey[0]}`); //(log query key)
     try {
       const res = await codexRequest(
-        () => axiosClient.get(queryKey[0]),
-        { status: 200, data: null }
+        () => axiosClient.get(queryKey[0]), //(perform GET request)
+        { status: 200, data: null } //(mock offline result)
       );
       if (unauthorizedBehavior === 'returnNull' && res.status === 401) {
         console.log(`getQueryFn inner is returning null`);
         return null;
       }
-      const result = res.data;
+      const result = res.data; //(extract payload)
       console.log(`getQueryFn inner is returning ${JSON.stringify(result)}`);
       return result;
-    } catch (err) {
+    } catch (err) { //(handle query errors)
       if (
         unauthorizedBehavior === 'returnNull' &&
         axios.isAxiosError(err) &&
@@ -255,10 +255,10 @@ function getQueryFn(options) {
         return null;
       }
       console.error('getQueryFn error:', err);
-      throw formatAxiosError(err);
+      throw formatAxiosError(err); //(rethrow normalized error)
     }
-  };
-}
+  }; //(end returned QueryFunction)
+} //(end getQueryFn)
 
 const queryClient = new QueryClient({ // shared React Query client for the app
   defaultOptions: {
@@ -275,10 +275,10 @@ const queryClient = new QueryClient({ // shared React Query client for the app
   },
 });
 
-module.exports = {
+module.exports = { //(expose API helpers)
   apiRequest,      // Primary HTTP wrapper used across hooks
   getQueryFn,      // Factory for React Query query functions
   queryClient,     // Shared QueryClient instance
   formatAxiosError, // Normalizes axios errors for consumers
   axiosClient      // Pre-configured axios instance
-};
+}; //(end module exports)


### PR DESCRIPTION
## Summary
- expand inline comments for exports in index
- add detailed inline comments to axios helpers in lib/api

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68468db4b2dc832290af80f439c69f84