### PR TITLE
Add coverage for utility error and toast wrappers

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -286,9 +286,10 @@ function withToastLogging(functionName, operation) {
 module.exports = {
   // Async execution utilities for consistent error handling
   executeAsyncWithLogging,  // Standardized async operation wrapper
-  
+
   // Logging utilities for consistent debugging
   logFunction,        // Standardized function logging utility
+  withToastLogging,   // expose wrapper so tests can verify logging wrapper behaviour
   
   // Toast notification utilities for consistent user feedback
   showToast,      // Primary toast function with full customization options


### PR DESCRIPTION
## Summary
- export `withToastLogging` for testability
- extend test suite with cases for logging wrappers and error handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68490b5e90cc832296f7eb0e10e8abd1