### PR TITLE
Add API helper tests and exports

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -276,9 +276,14 @@ const queryClient = new QueryClient({ // shared React Query client for the app
 });
 
 module.exports = { //(expose API helpers)
-  apiRequest,      // Primary HTTP wrapper used across hooks
-  getQueryFn,      // Factory for React Query query functions
-  queryClient,     // Shared QueryClient instance
-  formatAxiosError, // Normalizes axios errors for consumers
-  axiosClient      // Pre-configured axios instance
+  buildRequestConfig,  // create axios config consistently
+  createMockResponse,  // produce standardized mock responses
+  handle401Error,      // unify 401 status handling
+  codexRequest,        // offline development wrapper
+  executeAxiosRequest, // axios wrapper with error handling
+  apiRequest,          // Primary HTTP wrapper used across hooks
+  getQueryFn,          // Factory for React Query query functions
+  queryClient,         // Shared QueryClient instance
+  formatAxiosError,    // Normalizes axios errors for consumers
+  axiosClient          // Pre-configured axios instance
 }; //(end module exports)


### PR DESCRIPTION
## Summary
- export internal helpers from `lib/api.js`
- extend the test harness to run tests sequentially
- add unit tests for buildRequestConfig, createMockResponse, handle401Error
- test codexRequest and executeAxiosRequest behaviours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68490b61bf4c8322bc493b4369ffad32