### PR TITLE
Add hook helper tests

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -729,6 +729,10 @@ const { apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient } = r
 
 module.exports = {
   useAsyncAction,      // hook for async operations
+  executeWithLoadingState, // helper for loading state management (exported for testing)
+  useStableCallbackWithHandlers, // helper for stable callbacks with handlers
+  useAsyncStateWithCallbacks, // helper for async state with callbacks
+  useCallbackWithErrorHandling, // helper for callback error handling
   useDropdownData,     // manage dropdown state
   createDropdownListHook, // factory for typed dropdown hooks
   useDropdownToggle,   // open/close state for dropdowns


### PR DESCRIPTION
## Summary
- expose helper functions from `lib/hooks.js`
- add unit tests using `renderHook` for hook helper utilities

## Testing
- `npm test` *(fails: The current testing environment is not configured to support act(...))*

------
https://chatgpt.com/codex/tasks/task_b_68490b67104083229bf66a431fb999ec