### PR TITLE
Handle SSR in useIsMobile

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -413,11 +413,13 @@ const MOBILE_BREAKPOINT = 768;
  * @returns {boolean} Returns true if viewport is mobile-sized, false otherwise
  */
 function useIsMobile() {
+  console.log(`useIsMobile is running with none`); // log invocation for debugging
   // Initialize with undefined to prevent SSR/hydration mismatches
   // This will be set to the correct value immediately after mount
   const [isMobile, setIsMobile] = useState(undefined);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return; // skip effect when window absent
     // Create media query list for mobile breakpoint
     // Using max-width ensures no overlap between mobile and desktop states
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
@@ -440,6 +442,7 @@ function useIsMobile() {
 
   // Convert to boolean to ensure consistent return type
   // !! converts undefined to false, which is appropriate for SSR scenarios
+  console.log(`useIsMobile is returning ${!!isMobile}`); // log return value for traceability
   return !!isMobile;
 }
 


### PR DESCRIPTION
## Summary
- safeguard useIsMobile for SSR by checking `window`
- enable qtests stubs and extend axios mock
- test useIsMobile with missing `window`

## Testing
- `npm test` *(fails: useDropdownData and useToastAction integration sequence, useAuthRedirect reacts to auth state changes)*

------
https://chatgpt.com/codex/tasks/task_b_684925ffaf7083229eee81473461bc0a