### PR TITLE
Improve showToast validation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,6 +73,7 @@ async function executeAsyncWithLogging(operation, operationName, errorHandler) {
  * @throws {Error} Re-throws any errors from the toast function for proper error handling
  */
 const showToast = withToastLogging('showToast', function(toast, message, title, variant) { // create and log toast
+  if (typeof toast !== 'function') { throw new Error('showToast requires a function for `toast` parameter'); } // validate toast function before calling
   // Call the injected toast function with standardized parameter structure
   // This object structure is compatible with most popular toast libraries
   return toast({ title: title, description: message, variant: variant });

--- a/test.js
+++ b/test.js
@@ -155,6 +155,7 @@ require = function(id) { // Intercept require calls to stub axios only
 }; //
 
 global.window = mockWindow;
+global.PopStateEvent = class PopStateEvent { constructor(type, opts={}){ this.type=type; this.state=opts.state||null; } }; // stub for auth redirect tests
 
 // Test utilities
 let testCount = 0;
@@ -396,9 +397,13 @@ runTest('showToast error handling and propagation', () => {
   }, 'Should propagate toast system errors');
   
   // Test with null toast function
-  assertThrows(() => {
+  let errorMsg;
+  try {
     showToast(null, 'Test message');
-  }, 'Should handle null toast function');
+  } catch (err) {
+    errorMsg = err.message;
+  }
+  assertEqual(errorMsg, 'showToast requires a function for `toast` parameter', 'Should handle null toast function');
 });
 
 runTest('stopEvent comprehensive behavior', () => {
@@ -1394,6 +1399,7 @@ testQueue.then(() => { // wait for queued tests before reporting
   // Restore original environment after tests complete
   require = originalRequire;
   global.window = originalWindow;
+  delete global.PopStateEvent; // cleanup custom event constructor
 console.log('\n📊 DETAILED TEST SUMMARY');
 console.log('='.repeat(60));
 


### PR DESCRIPTION
## Summary
- validate toast function in `showToast`
- assert error message in showToast tests
- stub `PopStateEvent` for auth redirect tests

## Testing
- `npm test --silent` *(fails: useDropdownData and useAuthRedirect integration tests)*

------
https://chatgpt.com/codex/tasks/task_b_68492604dce88322843fe8dd476f32d8