### PR TITLE
Fix pushState usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ React hook for handling authentication-based redirects.
 **Parameters:**
 - `target` (string): The target URL to redirect to
 - `condition` (boolean): The condition that triggers the redirect
+- Gracefully skips navigation when `window.history.pushState` is unavailable
 
 ## Utility Functions
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -706,10 +706,12 @@ function useToastAction(asyncFn, successMsg, refresh) {
 function useAuthRedirect(target, condition) { // redirect users when condition is met
   console.log(`useAuthRedirect is running with ${target}, ${condition}`);
   
-  const setLocation = (path) => { // push location state for SPAs
-    if (typeof window !== 'undefined') {
-      window.history.pushState({}, '', path);
-      window.dispatchEvent(new PopStateEvent('popstate'));
+  const setLocation = (path) => { // push location state for SPAs when supported
+    if (typeof window !== 'undefined' && window.history && typeof window.history.pushState === 'function') { // verify history API exists before navigation
+      window.history.pushState({}, '', path); // update history state when pushState is available
+      if (typeof PopStateEvent === 'function') { // ensure event constructor exists before dispatch
+        window.dispatchEvent(new PopStateEvent('popstate')); // fire popstate event for SPA routing
+      }
     }
   };
 

--- a/test.js
+++ b/test.js
@@ -997,6 +997,14 @@ runTest('useAuthRedirect reacts to auth state changes', async () => {
   assertEqual(mockWindow._lastPushState.url, '/dashboard', 'Redirect should occur after login');
 });
 
+runTest('useAuthRedirect handles missing pushState gracefully', () => {
+  const originalPushState = mockWindow.history.pushState; // store original function to restore after test
+  delete mockWindow.history.pushState; // simulate environment without pushState
+  renderHook(() => useAuthRedirect('/fallback', true));
+  assert(mockWindow._lastPushState === null, 'Redirect should be skipped when pushState is unavailable');
+  mockWindow.history.pushState = originalPushState; // restore original pushState for subsequent tests
+});
+
 // =============================================================================
 // ERROR HANDLING TESTS
 // =============================================================================


### PR DESCRIPTION
## Summary
- check for `history.pushState` and `PopStateEvent` existence before using them
- document the fallback behaviour in README
- add regression test for auth redirect when `pushState` is missing

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_684926100db0832297a7827162ae1681