### PR TITLE
Add debug logging helper

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 
 const { QueryClient } = require("@tanstack/react-query"); // React Query core client
 const axios = require("axios"); // HTTP client used for API requests
+const { debugLog } = require('./utils'); // logging helper to silence production output
 
 /**
  * API Module: Centralized HTTP Request Management and React Query Integration
@@ -148,14 +149,14 @@ async function executeAxiosRequest(axiosCall, unauthorizedBehavior, mockResponse
  * @returns {Promise} Request result or mock response
  */
 async function codexRequest(requestFn, mockResponse) { //(handle codex offline logic)
-  console.log(`codexRequest is running with ${process.env.OFFLINE_MODE}`); //(log offline mode state)
+  debugLog(`codexRequest is running with ${process.env.OFFLINE_MODE}`); // dev-only log of offline state
   try {
     if (process.env.OFFLINE_MODE === `true`) {
-      console.log(`codexRequest is returning ${JSON.stringify(mockResponse)}`); //(return mock response when offline)
+      debugLog(`codexRequest is returning ${JSON.stringify(mockResponse)}`); // indicate mocked response
       return mockResponse; //(provide mock network result)
     }
     const res = await requestFn();
-    console.log(`codexRequest is returning ${JSON.stringify(res)}`); //(return actual response)
+    debugLog(`codexRequest is returning ${JSON.stringify(res)}`); // log real response when dev
     return res; //(pass through real network result)
   } catch (err) {
     throw err; //(rethrow request errors for caller handling)
@@ -168,7 +169,7 @@ async function codexRequest(requestFn, mockResponse) { //(handle codex offline l
  * @returns {Error} Formatted error object
  */
 function formatAxiosError(err) { //(normalize axios error)
-  console.log(`formatAxiosError is running with ${err}`);
+  debugLog(`formatAxiosError is running with ${err}`); // log input only in dev
   try {
     if (axios.isAxiosError(err)) {
       const status = err.response?.status ?? 500;
@@ -187,10 +188,10 @@ function formatAxiosError(err) { //(normalize axios error)
       }
       
       const error = new Error(`${status}: ${dataString}`);
-      console.log(`formatAxiosError is returning ${error}`);
+      debugLog(`formatAxiosError is returning ${error}`); // show formatted error in dev
       return error;
     }
-    console.log(`formatAxiosError is returning ${err}`);
+    debugLog(`formatAxiosError is returning ${err}`); // fallback non-axios error
     return err;
   } catch (error) {
     console.error('formatAxiosError error:', error);
@@ -207,14 +208,14 @@ function formatAxiosError(err) { //(normalize axios error)
  * @returns {Promise} Response data
  */
 async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
-  console.log(`apiRequest is running with ${method} ${url}`); //(log request info)
+  debugLog(`apiRequest is running with ${method} ${url}`); // log request in dev
   try {
     const response = await codexRequest(
       () => axiosClient.request({ url, method, data }), //(perform axios call)
       { data: { message: 'Mocked in Codex' } } //(mock offline response)
     );
     const result = response.data; //(extract data payload)
-    console.log(`apiRequest is returning ${JSON.stringify(result)}`);
+    debugLog(`apiRequest is returning ${JSON.stringify(result)}`); // show result only in dev
     return result;
   } catch (err) { //(handle axios errors)
     console.error('apiRequest error:', err);
@@ -232,18 +233,18 @@ function getQueryFn(options) { //(factory for query functions)
   const { on401: unauthorizedBehavior } = options; //(extract 401 strategy)
   
   return async ({ queryKey }) => { //(returned QueryFunction)
-    console.log(`getQueryFn inner is running with ${queryKey[0]}`); //(log query key)
+    debugLog(`getQueryFn inner is running with ${queryKey[0]}`); // show query key in dev
     try {
       const res = await codexRequest(
         () => axiosClient.get(queryKey[0]), //(perform GET request)
         { status: 200, data: null } //(mock offline result)
       );
       if (unauthorizedBehavior === 'returnNull' && res.status === 401) {
-        console.log(`getQueryFn inner is returning null`);
+        debugLog(`getQueryFn inner is returning null`); // log 401 return
         return null;
       }
       const result = res.data; //(extract payload)
-      console.log(`getQueryFn inner is returning ${JSON.stringify(result)}`);
+      debugLog(`getQueryFn inner is returning ${JSON.stringify(result)}`); // log result when dev
       return result;
     } catch (err) { //(handle query errors)
       if (
@@ -251,7 +252,7 @@ function getQueryFn(options) { //(factory for query functions)
         axios.isAxiosError(err) &&
         err.response?.status === 401
       ) {
-        console.log(`getQueryFn inner is returning null`);
+        debugLog(`getQueryFn inner is returning null`); // log 401 null return in catch
         return null;
       }
       console.error('getQueryFn error:', err);

--- a/lib/errorHandling.js
+++ b/lib/errorHandling.js
@@ -6,6 +6,7 @@
  * the application, reducing code duplication and ensuring consistent
  * error processing, logging, and propagation.
  */
+const { debugLog } = require('./utils'); // import logging helper for conditional output
 
 /**
  * Execute a function with standardized error handling
@@ -21,9 +22,9 @@
  */
 async function executeWithErrorHandling(fn, functionName, errorTransform) {
   try { // attempt to execute the provided function
-    console.log(`${functionName} executing...`);
+    debugLog(`${functionName} executing...`); // dev-time log
     const result = await fn();
-    console.log(`${functionName} completed successfully`);
+    debugLog(`${functionName} completed successfully`); // indicate success in dev
     return result;
   } catch (error) { // standard error path
     console.error(`${functionName} error:`, error);
@@ -48,9 +49,9 @@ async function executeWithErrorHandling(fn, functionName, errorTransform) {
  */
 function executeSyncWithErrorHandling(fn, functionName, errorTransform) {
   try { // run the synchronous function
-    console.log(`${functionName} executing...`);
+    debugLog(`${functionName} executing...`); // log sync execution start
     const result = fn();
-    console.log(`${functionName} completed successfully`);
+    debugLog(`${functionName} completed successfully`); // log sync completion
     return result;
   } catch (error) { // handle any thrown errors
     console.error(`${functionName} error:`, error);

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -16,7 +16,7 @@
  * - Error handling and loading states as first-class concerns
  */
 const { useState, useCallback, useEffect } = require('react');
-const { showToast, toastSuccess, toastError } = require('./utils');
+const { showToast, toastSuccess, toastError, debugLog } = require('./utils'); // include conditional logger
 
 /**
  * Helper function for managing loading state with async operations
@@ -137,17 +137,17 @@ function useCallbackWithErrorHandling(operation, options, deps) {
  * @returns {Array} Returns [run, isLoading] tuple
  */
 function useAsyncAction(asyncFn, options) {
-  console.log(`useAsyncAction is running with ${asyncFn}`);
+  debugLog(`useAsyncAction is running with ${asyncFn}`); // log hook creation only in dev
   const [isLoading, setIsLoading] = useState(false);
 
   // useCallback ensures the returned function has a stable reference across re-renders
   // This prevents child components from re-rendering unnecessarily when they depend on this function
   const run = useCallback(async (...args) => {
-    console.log(`run is running with ${JSON.stringify(args)}`);
+    debugLog(`run is running with ${JSON.stringify(args)}`); // log invocation args
     try {
       setIsLoading(true);
       const result = await asyncFn(...args);
-      console.log(`run is returning ${JSON.stringify(result)}`);
+      debugLog(`run is returning ${JSON.stringify(result)}`); // log result in dev
       // Optional chaining used here because callbacks are optional
       // onSuccess is called with the result, allowing for data processing or UI updates
       options?.onSuccess?.(result);
@@ -164,7 +164,7 @@ function useAsyncAction(asyncFn, options) {
     }
   }, [asyncFn, options]); // Dependencies ensure the callback updates when these change
 
-  console.log(`useAsyncAction is returning ${JSON.stringify(["run", isLoading])}`);
+  debugLog(`useAsyncAction is returning ${JSON.stringify(["run", isLoading])}`); // log return tuple
   return [run, isLoading];
 }
 
@@ -191,17 +191,17 @@ function useAsyncAction(asyncFn, options) {
  * @returns {Object} Returns {items, isLoading, fetchData}
  */
 function useDropdownData(fetcher, toast, user) {
-  console.log(`useDropdownData is running with fetcher`);
+  debugLog(`useDropdownData is running with fetcher`); // log hook init
   // Initialize with empty array to ensure components can safely map over items immediately
   const [items, setItems] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
   async function fetchData() {
-    console.log(`fetchData is running with no params`);
+    debugLog(`fetchData is running with no params`); // dev log for fetch start
     try {
       setIsLoading(true);
       const data = await fetcher();
-      console.log(`fetchData is returning ${JSON.stringify(data)}`);
+      debugLog(`fetchData is returning ${JSON.stringify(data)}`); // dev log result
       setItems(data);
     } catch (error) {
       console.error('fetchData error:', error);
@@ -223,7 +223,7 @@ function useDropdownData(fetcher, toast, user) {
     }
   }, [user]); // Only re-run when user object changes
 
-  console.log(`useDropdownData is returning ${JSON.stringify({ items, isLoading })}`);
+  debugLog(`useDropdownData is returning ${JSON.stringify({ items, isLoading })}`); // final state log
   return { items, isLoading, fetchData };
 }
 
@@ -250,19 +250,19 @@ function useDropdownData(fetcher, toast, user) {
  * @returns {Function} Returns a custom hook function
  */
 function createDropdownListHook(fetcher) {
-  console.log(`createDropdownListHook is running with fetcher`);
+  debugLog(`createDropdownListHook is running with fetcher`); // log factory init
   
   // Return a custom hook that closes over the fetcher function
   // This creates a specialized version of useDropdownData for a specific data source
   function useList(toast, user) {
-    console.log(`useList is running with no params`);
+    debugLog(`useList is running with no params`); // log call
     // Delegate to the generic useDropdownData hook with the pre-bound fetcher
     const result = useDropdownData(fetcher, toast, user);
-    console.log(`useList is returning ${JSON.stringify(result)}`);
+    debugLog(`useList is returning ${JSON.stringify(result)}`); // log result
     return result;
   }
   
-  console.log(`createDropdownListHook is returning ${useList}`);
+  debugLog(`createDropdownListHook is returning ${useList}`); // confirm returned hook
   return useList;
 }
 
@@ -285,26 +285,26 @@ function createDropdownListHook(fetcher) {
  * @returns {Object} Returns {isOpen, toggleOpen, close}
  */
 function useDropdownToggle() {
-  console.log(`useDropdownToggle is running with no params`)
+  debugLog(`useDropdownToggle is running with no params`) // log init
   // Default to false (closed) as dropdowns should start closed
   const [isOpen, setIsOpen] = useState(false)
 
   function toggleOpen() {
     const newOpen = !isOpen
-    console.log(`toggleOpen is running with ${isOpen}`)
+    debugLog(`toggleOpen is running with ${isOpen}`) // log current state
     setIsOpen(newOpen)
-    console.log(`toggleOpen has run resulting in a final value of ${newOpen}`)
+    debugLog(`toggleOpen has run resulting in a final value of ${newOpen}`) // log result
   }
 
   // Explicit close function for cases where we need to close regardless of current state
   // This is common for escape key handlers, outside clicks, or after selection
   function close() {
-    console.log(`close is running with no params`)
+    debugLog(`close is running with no params`) // log close start
     setIsOpen(false)
-    console.log(`close has run resulting in a final value of false`)
+    debugLog(`close has run resulting in a final value of false`) // log close result
   }
 
-  console.log(`useDropdownToggle is returning ${JSON.stringify({ isOpen })}`)
+  debugLog(`useDropdownToggle is returning ${JSON.stringify({ isOpen })}`) // log return state
   return { isOpen, toggleOpen, close }
 }
 
@@ -331,7 +331,7 @@ function useDropdownToggle() {
  * @returns {Object} Returns {editingId, fields, setField, startEdit, cancelEdit}
  */
 function useEditForm(initialState) {
-  console.log(`useEditForm is running with ${JSON.stringify(initialState)}`);
+  debugLog(`useEditForm is running with ${JSON.stringify(initialState)}`); // log init state
   // editingId tracks which item is currently being edited; null means no item is being edited
   const [editingId, setEditingId] = useState(null);
   // fields holds the current form values
@@ -339,14 +339,14 @@ function useEditForm(initialState) {
 
   // Individual field setter using functional update pattern to avoid stale closures
   function setField(key, value) {
-    console.log(`setField is running with ${String(key)}, ${value}`);
+    debugLog(`setField is running with ${String(key)}, ${value}`); // dev log field change
     setFields((prev) => ({ ...prev, [key]: value }));
-    console.log(`setField has run resulting in a final value of ${value}`);
+    debugLog(`setField has run resulting in a final value of ${value}`); // confirm update
   }
 
   // Start editing an existing item by populating form fields with item data
   function startEdit(item) {
-    console.log(`startEdit is running with ${item._id}`);
+    debugLog(`startEdit is running with ${item._id}`); // log item editing start
     setEditingId(item._id);
     
     // Start with initialState structure to ensure all expected fields are present
@@ -359,20 +359,20 @@ function useEditForm(initialState) {
       }
     });
     setFields(newFields);
-    console.log(`startEdit has run resulting in a final value of ${item._id}`);
+    debugLog(`startEdit has run resulting in a final value of ${item._id}`); // confirm start
   }
 
   // Cancel editing and reset form to initial state
   function cancelEdit() {
-    console.log(`cancelEdit is running with no params`);
+    debugLog(`cancelEdit is running with no params`); // log cancel call
     setEditingId(null);
     // Reset to initialState provides a clean slate, useful for both canceling edits
     // and preparing the form for creating new items
     setFields(initialState);
-    console.log(`cancelEdit has run resulting in a final value of null`);
+    debugLog(`cancelEdit has run resulting in a final value of null`); // confirm cancel
   }
 
-  console.log(`useEditForm is returning state`);
+  debugLog(`useEditForm is returning state`); // final log
   return { editingId, fields, setField, startEdit, cancelEdit };
 }
 
@@ -678,7 +678,7 @@ function useToast() {
  * @returns {Array} Returns [run, isLoading] tuple
  */
 function useToastAction(asyncFn, successMsg, refresh) {
-  console.log(`useToastAction is running with ${asyncFn}, ${successMsg}`);
+  debugLog(`useToastAction is running with ${asyncFn}, ${successMsg}`); // log hook init
   const { toast } = useToast();
   const [run, isLoading] = useAsyncAction(asyncFn, {
     onSuccess: async (result) => {
@@ -686,7 +686,7 @@ function useToastAction(asyncFn, successMsg, refresh) {
       if (refresh) { 
         await refresh(); 
       }
-      console.log(`useToastAction onSuccess returning ${JSON.stringify(result)}`);
+      debugLog(`useToastAction onSuccess returning ${JSON.stringify(result)}`); // log success output
       return result;
     },
     onError: (error) => {
@@ -694,7 +694,7 @@ function useToastAction(asyncFn, successMsg, refresh) {
       toastError(toast, msg);
     },
   });
-  console.log(`useToastAction is returning ${JSON.stringify([run, isLoading])}`);
+  debugLog(`useToastAction is returning ${JSON.stringify([run, isLoading])}`); // log tuple
   return [run, isLoading];
 }
 
@@ -704,7 +704,7 @@ function useToastAction(asyncFn, successMsg, refresh) {
  * @param {boolean} condition - The condition that triggers the redirect
  */
 function useAuthRedirect(target, condition) { // redirect users when condition is met
-  console.log(`useAuthRedirect is running with ${target}, ${condition}`);
+  debugLog(`useAuthRedirect is running with ${target}, ${condition}`); // log setup
   
   const setLocation = (path) => { // push location state for SPAs
     if (typeof window !== 'undefined') {
@@ -714,14 +714,14 @@ function useAuthRedirect(target, condition) { // redirect users when condition i
   };
 
   useEffect(() => {
-    console.log(`useAuthRedirect effect is running with ${condition}`);
+    debugLog(`useAuthRedirect effect is running with ${condition}`); // log effect run
     if (condition) {
       setLocation(target);
-      console.log(`useAuthRedirect is returning redirect to ${target}`);
+      debugLog(`useAuthRedirect is returning redirect to ${target}`); // log redirect
     }
   }, [condition, target]);
 
-  console.log(`useAuthRedirect has run resulting in a final value of no return`);
+  debugLog(`useAuthRedirect has run resulting in a final value of no return`); // final log
 }
 
 const { stopEvent } = require('./utils'); // event helper utilities

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,11 +27,23 @@
  * @param {Function} errorHandler - Optional custom error handler
  * @returns {Promise} Result of the operation or re-throws error
  */
+/**
+ * Conditionally log to the console in non-production environments
+ *
+ * This helper preserves debugging output during development while keeping
+ * production logs clean.
+ *
+ * @param {string} message - Message to log
+ */
+function debugLog(message) {
+  if (process.env.NODE_ENV !== 'production') { console.log(message); } // avoid noisy logs in production
+}
+
 async function executeAsyncWithLogging(operation, operationName, errorHandler) {
-  console.log(`${operationName} is running`);
+  debugLog(`${operationName} is running`); // indicate async action start only when not production
   try {
     const result = await operation();
-    console.log(`${operationName} completed successfully`);
+    debugLog(`${operationName} completed successfully`); // show success only in dev
     return result;
   } catch (error) {
     console.error(`${operationName} error:`, error);
@@ -106,14 +118,14 @@ const showToast = withToastLogging('showToast', function(toast, message, title, 
  * @throws {Error} Re-throws any underlying toast errors to preserve error chain
  */
 function toastError(toast, message, title = `Error`) {
-  console.log(`toastError is running with ${message}`);
+  debugLog(`toastError is running with ${message}`); // hide logs in production
   try {
     // Use destructive variant to ensure error messages have appropriate visual treatment
     const result = showToast(toast, message, title, `destructive`);
-    console.log(`toastError is returning ${JSON.stringify(result)}`);
+    debugLog(`toastError is returning ${JSON.stringify(result)}`); // confirm toast result
     return result;
   } catch (err) {
-    console.log(`toastError has run resulting in a final value of failure`);
+    debugLog(`toastError has run resulting in a final value of failure`); // log failure for debugging
     // Preserve error chain for debugging while allowing graceful degradation
     throw err;
   }
@@ -146,14 +158,14 @@ function toastError(toast, message, title = `Error`) {
  * @throws {Error} Re-throws any underlying toast errors to preserve error chain
  */
 function toastSuccess(toast, message, title = `Success`) {
-  console.log(`toastSuccess is running with ${message}`);
+  debugLog(`toastSuccess is running with ${message}`); // hide success logs in production
   try {
     // Use default variant for positive but not overwhelming visual feedback
     const result = showToast(toast, message, title);
-    console.log(`toastSuccess is returning ${JSON.stringify(result)}`);
+    debugLog(`toastSuccess is returning ${JSON.stringify(result)}`); // confirm toast output in dev
     return result;
   } catch (err) {
-    console.log(`toastSuccess has run resulting in a final value of failure`);
+    debugLog(`toastSuccess has run resulting in a final value of failure`); // log failure path for dev
     // Maintain error chain integrity for debugging
     throw err;
   }
@@ -189,7 +201,7 @@ function toastSuccess(toast, message, title = `Success`) {
  * @throws {Error} Re-throws any errors to preserve debugging information
  */
 function stopEvent(e) {
-  console.log(`stopEvent is running with ${e.type}`);
+  debugLog(`stopEvent is running with ${e.type}`); // event info only during dev
   try {
     // Prevent the browser's default action for this event
     // This stops form submissions, link navigation, right-click menus, etc.
@@ -199,9 +211,9 @@ function stopEvent(e) {
     // This prevents parent click handlers from firing unexpectedly
     e.stopPropagation();
     
-    console.log(`stopEvent has run resulting in a final value of undefined`);
+    debugLog(`stopEvent has run resulting in a final value of undefined`); // confirm success
   } catch (err) {
-    console.log(`stopEvent has run resulting in a final value of failure`);
+    debugLog(`stopEvent has run resulting in a final value of failure`); // log failure path
     // Re-throw to allow calling code to handle the error appropriately
     // This preserves the error chain for debugging while allowing graceful degradation
     throw err;
@@ -221,19 +233,19 @@ function stopEvent(e) {
 function logFunction(functionName, phase, data) {
   switch (phase) {
     case 'entry':
-      console.log(`${functionName} is running with ${data}`);
+      debugLog(`${functionName} is running with ${data}`); // track entry only when not production
       break;
     case 'exit':
-      console.log(`${functionName} is returning ${JSON.stringify(data)}`);
+      debugLog(`${functionName} is returning ${JSON.stringify(data)}`); // show return values in dev
       break;
     case 'completion':
-      console.log(`${functionName} has run resulting in a final value of ${data}`);
+      debugLog(`${functionName} has run resulting in a final value of ${data}`); // completion log
       break;
     case 'error':
-      console.log(`${functionName} has run resulting in a final value of failure`);
+      debugLog(`${functionName} has run resulting in a final value of failure`); // error path log
       break;
     default:
-      console.log(`${functionName}: ${data}`);
+      debugLog(`${functionName}: ${data}`); // generic log fallback
   }
 }
 
@@ -288,6 +300,7 @@ module.exports = {
   executeAsyncWithLogging,  // Standardized async operation wrapper
 
   // Logging utilities for consistent debugging
+  debugLog,          // Conditional console.log wrapper to silence production logs
   logFunction,        // Standardized function logging utility
   withToastLogging,   // expose wrapper so tests can verify logging wrapper behaviour
   

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ const {
 const { buildRequestConfig, createMockResponse, handle401Error, codexRequest, executeAxiosRequest } = require('./lib/api.js'); // import internal API helpers for unit tests
 
 // Direct imports for internal utilities under test
-const { executeAsyncWithLogging, logFunction, withToastLogging } = require('./lib/utils.js'); // test logging helpers
+const { executeAsyncWithLogging, logFunction, withToastLogging, debugLog } = require('./lib/utils.js'); // test logging helpers and debugLog
 const { executeWithErrorHandling, executeSyncWithErrorHandling } = require('./lib/errorHandling.js'); // test error wrappers
 const { executeWithErrorToast, executeWithToastFeedback } = require('./lib/toastIntegration.js'); // test toast integration
 
@@ -483,6 +483,21 @@ runTest('logFunction outputs expected messages', () => {
   assert(messages.some(m => m.includes('testFn is returning')), 'Exit log expected');
   assert(messages.some(m => m.includes('final value of value')), 'Completion log expected');
   assert(messages.some(m => m.includes('final value of failure')), 'Error log expected');
+});
+
+runTest('debugLog obeys NODE_ENV setting', () => {
+  const logs = [];
+  const orig = console.log;
+  const origEnv = process.env.NODE_ENV;
+  console.log = (m) => logs.push(m);
+  process.env.NODE_ENV = 'development';
+  debugLog('dev');
+  process.env.NODE_ENV = 'production';
+  debugLog('prod');
+  process.env.NODE_ENV = origEnv;
+  console.log = orig;
+  assert(logs.includes('dev'), 'Should log in dev mode');
+  assert(!logs.includes('prod'), 'Should not log in production');
 });
 
 runTest('withToastLogging wraps function and preserves errors', () => {


### PR DESCRIPTION
## Summary
- add `debugLog` util that only logs when NODE_ENV isn't production
- use `debugLog` across utils, api, hooks and error handling
- test `debugLog` behaviour with NODE_ENV toggle

## Testing
- `npm test` *(fails: useDropdownData and useToastAction integration sequence, useAuthRedirect reacts to auth state changes)*

------
https://chatgpt.com/codex/tasks/task_b_68492613204083229aca6aa4de495596