### PR TITLE
Fix useToastAction callback stability

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -15,7 +15,7 @@
  * - Centralized state management where appropriate (toast system)
  * - Error handling and loading states as first-class concerns
  */
-const { useState, useCallback, useEffect } = require('react');
+const { useState, useCallback, useEffect, useMemo } = require('react'); // add useMemo for stable callback objects
 const { showToast, toastSuccess, toastError } = require('./utils');
 
 /**
@@ -691,20 +691,21 @@ function resetToastSystem() {
 function useToastAction(asyncFn, successMsg, refresh) {
   console.log(`useToastAction is running with ${asyncFn}, ${successMsg}`);
   const { toast } = useToast();
-  const [run, isLoading] = useAsyncAction(asyncFn, {
+  const callbacks = useMemo(() => ({
     onSuccess: async (result) => {
-      toastSuccess(toast, successMsg);
-      if (refresh) { 
-        await refresh(); 
+      toastSuccess(toast, successMsg); // trigger success toast with provided message
+      if (refresh) { // optional refresh after success
+        await refresh();
       }
       console.log(`useToastAction onSuccess returning ${JSON.stringify(result)}`);
       return result;
     },
     onError: (error) => {
       const msg = error instanceof Error ? error.message : `Operation failed`;
-      toastError(toast, msg);
+      toastError(toast, msg); // show error toast with message
     },
-  });
+  }), [toast, successMsg, refresh]); // memoize callbacks so useAsyncAction gets stable reference
+  const [run, isLoading] = useAsyncAction(asyncFn, callbacks); // stable callbacks keep run stable
   console.log(`useToastAction is returning ${JSON.stringify([run, isLoading])}`);
   return [run, isLoading];
 }


### PR DESCRIPTION
## Summary
- memoize callbacks passed to `useAsyncAction` inside `useToastAction`
- import `useMemo` from React

## Testing
- `node test.js` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_b_68499f7d0fe88322a42cfbcb071d99d3