### PR TITLE
Fix dropdown effect deps

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -221,7 +221,7 @@ function useDropdownData(fetcher, toast, user) {
     if (user) {
       fetchData();
     }
-  }, [user]); // Only re-run when user object changes
+  }, [user, fetcher, toast]); // ensure refetch when dependencies change
 
   console.log(`useDropdownData is returning ${JSON.stringify({ items, isLoading })}`);
   return { items, isLoading, fetchData };


### PR DESCRIPTION
## Summary
- rerun dropdown fetch when fetcher or toast change
- allow `renderHook` test helper to rerender
- add tests for dropdown dependency updates

## Testing
- `npm test --silent` *(fails: write EPIPE)*

------
https://chatgpt.com/codex/tasks/task_b_68499f80401c83229b4cbef7919af278