### PR TITLE
Improve hooks awaiting callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ React hook for handling async actions with loading state and error handling.
 - `options` (Object, optional): Configuration object
   - `onSuccess` (Function): Callback invoked when async operation succeeds
   - `onError` (Function): Callback invoked when async operation fails
+  - Callbacks may return Promises and will be awaited so errors propagate
 
 **Returns:** Array - `[run, isLoading]`
 
@@ -74,6 +75,8 @@ Factory function that creates typed dropdown hooks.
 
 ### useDropdownToggle()
 React hook for managing dropdown open/close state.
+
+This hook uses a functional state update when toggling to ensure rapid consecutive calls remain consistent.
 
 **Returns:** Object - `{isOpen, toggleOpen, close}`
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -52,10 +52,10 @@ function useStableCallbackWithHandlers(operation, callbacks, deps) {
   return useCallback(async (...args) => {
     try {
       const result = await operation(...args);
-      callbacks?.onSuccess?.(result);
+      await callbacks?.onSuccess?.(result); // await async callbacks so errors propagate
       return result;
     } catch (error) {
-      callbacks?.onError?.(error);
+      await callbacks?.onError?.(error); // await ensures rejection bubbles up
       throw error;
     }
   }, deps);
@@ -79,10 +79,10 @@ function useAsyncStateWithCallbacks(asyncFn, options) {
     return executeWithLoadingState(setIsLoading, async () => {
       try {
         const result = await asyncFn(...args);
-        options?.onSuccess?.(result);
+        await options?.onSuccess?.(result); // await async callbacks for proper chaining
         return result;
       } catch (error) {
-        options?.onError?.(error);
+        await options?.onError?.(error); // await ensures promise rejections propagate
         throw error;
       }
     });
@@ -106,10 +106,10 @@ function useCallbackWithErrorHandling(operation, options, deps) {
   return useCallback(async (...args) => {
     try {
       const result = await operation(...args);
-      options?.onSuccess?.(result);
+      await options?.onSuccess?.(result); // await allows async callbacks
       return result;
     } catch (error) {
-      options?.onError?.(error);
+      await options?.onError?.(error); // await ensures error callbacks can reject
       throw error;
     }
   }, deps);
@@ -150,12 +150,12 @@ function useAsyncAction(asyncFn, options) {
       console.log(`run is returning ${JSON.stringify(result)}`);
       // Optional chaining used here because callbacks are optional
       // onSuccess is called with the result, allowing for data processing or UI updates
-      options?.onSuccess?.(result);
+      await options?.onSuccess?.(result); // await to support async callbacks propagating failures
       return result;
     } catch (error) {
       console.error(`run error`, error);
       // onError callback allows for centralized error handling (e.g., showing toasts)
-      options?.onError?.(error);
+      await options?.onError?.(error); // await async error handling to bubble up
       // Re-throw to allow calling code to handle the error if needed
       throw error;
     } finally {
@@ -290,10 +290,8 @@ function useDropdownToggle() {
   const [isOpen, setIsOpen] = useState(false)
 
   function toggleOpen() {
-    const newOpen = !isOpen
     console.log(`toggleOpen is running with ${isOpen}`)
-    setIsOpen(newOpen)
-    console.log(`toggleOpen has run resulting in a final value of ${newOpen}`)
+    setIsOpen(v => { const next = !v; console.log(`toggleOpen has run resulting in a final value of ${next}`); return next; }) // functional update prevents stale closure when rapidly toggling
   }
 
   // Explicit close function for cases where we need to close regardless of current state


### PR DESCRIPTION
## Summary
- await callback results in async handlers to surface errors
- rely on functional updater for useDropdownToggle
- document that hook callbacks may return promises

## Testing
- `node test.js` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_b_6849da8c4e848322befb76fb1bda5913