### PR TITLE
Fix useIsMobile for no matchMedia

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -418,9 +418,13 @@ function useIsMobile() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return; // skip effect when window absent
+    if (!window.matchMedia) { // guard for environments without matchMedia
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT); // derive from width when matchMedia missing
+      return; // exit early without registering listeners
+    }
     // Create media query list for mobile breakpoint
     // Using max-width ensures no overlap between mobile and desktop states
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`); // safe because matchMedia exists
     
     // Handler function that updates state based on current window width
     // Uses window.innerWidth rather than mql.matches for more precise control

--- a/test.js
+++ b/test.js
@@ -1052,6 +1052,16 @@ runTest('useIsMobile falls back to addListener', () => {
   mockWindow.matchMedia = originalMatchMedia; // restore implementation
 });
 
+runTest('useIsMobile handles missing matchMedia', () => {
+  const originalMatchMedia = mockWindow.matchMedia; // keep for restore
+  mockWindow.matchMedia = undefined; // simulate old browser environment
+  mockWindow.innerWidth = 500; // set mobile width
+  const { result } = renderHook(() => useIsMobile());
+  assert(result.current === true, 'Should derive state from innerWidth when matchMedia absent');
+  assertEqual(mockWindow._mediaListeners.length, 0, 'Should not register listeners without matchMedia');
+  mockWindow.matchMedia = originalMatchMedia; // cleanup
+});
+
 runTest('useDropdownData and useToastAction integration sequence', async () => {
   resetToastSystem(); // ensure clean state for integration test
   const fetchCalls = [];


### PR DESCRIPTION
## Summary
- handle older browsers without `matchMedia`
- test missing `matchMedia` branch in `useIsMobile`

## Testing
- `DEBUG_TESTS=false node test.js` *(fails: huge output)*

------
https://chatgpt.com/codex/tasks/task_b_684a1fd214c083228773c8511e4af4dd