### PR TITLE
Fix auth redirect fallback

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -735,6 +735,8 @@ function useAuthRedirect(target, condition) { // redirect users when condition i
       if (typeof PopStateEvent === 'function') { // ensure event constructor exists before dispatch
         window.dispatchEvent(new PopStateEvent('popstate')); // fire popstate event for SPA routing
       }
+    } else if (typeof window !== 'undefined' && typeof window.location.assign === 'function') { // fallback to full page redirect when history API missing
+      window.location.assign(path); // navigate using traditional redirect
     }
   };
 


### PR DESCRIPTION
## Summary
- fallback to `window.location.assign` when `pushState` isn't available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a1fd4a18c8322a2851f74c36733e6