### PR TITLE
Handle invalid startEdit input

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -344,8 +344,12 @@ function useEditForm(initialState) {
 
   // Start editing an existing item by populating form fields with item data
   function startEdit(item) {
-    console.log(`startEdit is running with ${item._id}`);
-    setEditingId(item._id);
+    console.log(`startEdit is running with ${item && item._id}`); // log entry with safe access to id
+    if (!item || !item._id) { // validate item presence before proceeding
+      console.error(`startEdit error: invalid item ${JSON.stringify(item)}`); // surface invalid item details
+      return; // exit early when item is missing or malformed
+    }
+    setEditingId(item._id); // store id of item being edited
     
     // Start with initialState structure to ensure all expected fields are present
     const newFields = { ...initialState };

--- a/test.js
+++ b/test.js
@@ -1096,6 +1096,26 @@ runTest('useAuthRedirect handles missing pushState gracefully', () => {
   mockWindow.history.pushState = originalPushState; // restore original pushState for subsequent tests
 });
 
+runTest('useEditForm startEdit populates fields and editingId', () => {
+  const initial = { name: '', age: 0 };
+  const { result } = renderHook(() => useEditForm(initial));
+  TestRenderer.act(() => { result.current.startEdit({ _id: '1', name: 'Bob', age: 5 }); });
+  assertEqual(result.current.editingId, '1', 'Should store item id');
+  assertEqual(result.current.fields.name, 'Bob', 'Should copy name field');
+  assertEqual(result.current.fields.age, 5, 'Should copy age field');
+});
+
+runTest('useEditForm startEdit handles invalid item', () => {
+  const init = { title: 't' };
+  const { result } = renderHook(() => useEditForm(init));
+  TestRenderer.act(() => { result.current.startEdit(null); });
+  assert(result.current.editingId === null, 'EditingId should remain null with null item');
+  assertEqual(result.current.fields.title, 't', 'Fields should remain unchanged');
+  TestRenderer.act(() => { result.current.startEdit({ title: 'x' }); });
+  assert(result.current.editingId === null, 'EditingId should remain null when _id missing');
+  assertEqual(result.current.fields.title, 't', 'Fields should remain unchanged when _id missing');
+});
+
 // =============================================================================
 // ERROR HANDLING TESTS
 // =============================================================================


### PR DESCRIPTION
## Summary
- validate `startEdit` input to avoid runtime errors
- add tests for `useEditForm` ensuring `startEdit` works when given valid and invalid items

## Testing
- `npm test` *(fails to provide summary due to log size but executed)*

------
https://chatgpt.com/codex/tasks/task_b_684a1fdafaec832294fa8fc07cd07821