### PR TITLE
Stabilize dropdown toggle callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Factory function that creates typed dropdown hooks.
 ### useDropdownToggle()
 React hook for managing dropdown open/close state.
 
-This hook uses a functional state update when toggling to ensure rapid consecutive calls remain consistent.
+`toggleOpen` is a memoized callback using a functional state update so rapid consecutive calls remain consistent. `close` is also memoized to provide a stable reference for event handlers.
 
 **Returns:** Object - `{isOpen, toggleOpen, close}`
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -276,14 +276,11 @@ function useDropdownToggle() {
   // Default to false (closed) as dropdowns should start closed
   const [isOpen, setIsOpen] = useState(false)
 
-  function toggleOpen() {
-  }
+  const toggleOpen = useCallback(() => setIsOpen(prev => !prev), []) // memoized toggle to keep reference stable
 
   // Explicit close function for cases where we need to close regardless of current state
   // This is common for escape key handlers, outside clicks, or after selection
-  function close() {
-    setIsOpen(false)
-  }
+  const close = useCallback(() => setIsOpen(false), []) // memoized close for reliable reference
 
   return { isOpen, toggleOpen, close }
 }

--- a/test.js
+++ b/test.js
@@ -1106,6 +1106,16 @@ runTest('useAuthRedirect handles missing pushState gracefully', () => {
   mockWindow.history.pushState = originalPushState; // restore original pushState for subsequent tests
 });
 
+runTest('useDropdownToggle toggles and closes correctly', () => {
+  const { result } = renderHook(() => useDropdownToggle());
+  TestRenderer.act(() => { result.current.toggleOpen(); });
+  assert(result.current.isOpen === true, 'Toggle should open dropdown');
+  TestRenderer.act(() => { result.current.toggleOpen(); });
+  assert(result.current.isOpen === false, 'Toggle should close dropdown');
+  TestRenderer.act(() => { result.current.close(); });
+  assert(result.current.isOpen === false, 'Close should force closed state');
+});
+
 runTest('useEditForm startEdit populates fields and editingId', () => {
   const initial = { name: '', age: 0 };
   const { result } = renderHook(() => useEditForm(initial));


### PR DESCRIPTION
## Summary
- stabilize `toggleOpen` and `close` callbacks in `useDropdownToggle`
- document updated behavior in README
- add unit test for the dropdown toggle hook

## Testing
- `node test-simple.js` *(fails: apiRequest basic functionality: 500)*

------
https://chatgpt.com/codex/tasks/task_b_684bbb7d64c08322a01f8c6b549fbf19