### PR TITLE
Fix async error handler awaiting

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,7 @@ async function executeAsyncWithLogging(operation, operationName, errorHandler) {
     return result;
   } catch (error) {
     if (errorHandler) {
-      return errorHandler(error);
+      return await errorHandler(error); // await handler so async rejections propagate
     }
     throw error;
   }


### PR DESCRIPTION
## Summary
- await async error handlers in `executeAsyncWithLogging`
- test async handler resolution and rejection handling

## Testing
- `npm test` *(fails: React warnings prevent completion)*

------
https://chatgpt.com/codex/tasks/task_b_684bbb977f248322a51f6935cc5f9f02