### PR TITLE
Fix toast error handler and add regression test

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -198,10 +198,10 @@ function useDropdownData(fetcher, toast, user) {
       const data = await fetcher();
       setItems(data);
     } catch (error) {
-      // Optional chaining used because toast integration is optional
-      // This allows the hook to work even when toast system isn't available
-      if (toast && toast.error) {
-        toast.error(`Failed to load data.`);
+      // Guard against non-function toast.error so the hook doesn't throw at runtime
+      // Toast integration is optional and should fail silently when misconfigured
+      if (toast && typeof toast.error === 'function') { // ensure error handler is callable
+        toast.error(`Failed to load data.`); // surface failure via toast notification
       }
     } finally {
       setIsLoading(false);

--- a/test.js
+++ b/test.js
@@ -1016,6 +1016,14 @@ runTest('useDropdownData refetches when toast changes', async () => {
   assertEqual(calls, 2, 'Fetch should run again when toast instance changes');
 });
 
+runTest('useDropdownData skips toast error when not a function', async () => {
+  const fetcher = async () => { throw new Error('fail'); };
+  const { result } = renderHook(() => useDropdownData(fetcher, { error: 'text' }, { id: 'u3' }));
+  await TestRenderer.act(async () => { await result.current.fetchData(); });
+  assert(Array.isArray(result.current.items), 'Hook should not crash on invalid toast');
+  assert(result.current.isLoading === false, 'Loading state resets after failure');
+});
+
 runTest('useIsMobile integration with window API', () => {
   assert(typeof useIsMobile === 'function', 'useIsMobile should be a function'); // Export validation
 


### PR DESCRIPTION
## Summary
- guard `toast.error` usage in `useDropdownData`
- test that `useDropdownData` handles a non-function `toast.error` property

## Testing
- `node test.js` *(fails: process did not finish within time limit)*

------
https://chatgpt.com/codex/tasks/task_b_684bbb999a5c8322b3766dee579d96a7