### PR TITLE
Handle undefined in safeStringify

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -43,9 +43,10 @@ function isObject(value) {
  */
 function safeStringify(value, fallback = '[Circular Reference]') {
   try {
-    return JSON.stringify(value);
+    const str = JSON.stringify(value); // convert value to string; may return undefined for unsupported types
+    return str === undefined ? fallback : str; // use fallback when JSON.stringify yields undefined
   } catch (error) {
-    return fallback;
+    return fallback; // return fallback when JSON.stringify throws
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -578,6 +578,14 @@ runTest('safeStringify handles circular references gracefully', () => {
   assertEqual(safeStringify(normal), JSON.stringify(normal), 'Should stringify non-circular objects');
 });
 
+runTest('safeStringify(undefined) returns fallback string', () => {
+  assertEqual(
+    safeStringify(undefined),
+    '[Circular Reference]',
+    'Should return fallback when JSON.stringify returns undefined'
+  );
+});
+
 // =============================================================================
 // UNIT TESTS - API FUNCTIONS
 // =============================================================================


### PR DESCRIPTION
## Summary
- improve `safeStringify` fallback handling
- test `safeStringify(undefined)`

## Testing
- `node test.js` *(fails: interrupted after ~40s)*

------
https://chatgpt.com/codex/tasks/task_b_684bcd194ae4832280793ccec2bf407f