### PR TITLE
Fix circular logging

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,6 +14,7 @@
  * title/description/variant parameters, making the module adaptable to
  * different UI libraries (shadcn/ui, Chakra UI, Material-UI, etc.).
  */
+const { safeStringify } = require("./validation.js"); // safe stringify to avoid circular JSON errors
 
 /**
  * Execute an async operation with standardized error handling and logging
@@ -213,7 +214,7 @@ function logFunction(functionName, phase, data) {
       console.log(`${functionName} is running with ${data}`);
       break;
     case 'exit':
-      console.log(`${functionName} is returning ${JSON.stringify(data)}`);
+      console.log(`${functionName} is returning ${safeStringify(data)}`); // safeStringify prevents circular reference errors
       break;
     case 'completion':
       console.log(`${functionName} has run resulting in a final value of ${data}`);

--- a/test.js
+++ b/test.js
@@ -578,6 +578,20 @@ runTest('safeStringify handles circular references gracefully', () => {
   assertEqual(safeStringify(normal), JSON.stringify(normal), 'Should stringify non-circular objects');
 });
 
+runTest('logFunction handles circular references on exit', () => {
+  const cyc = {};
+  cyc.self = cyc; // create cycle
+  const orig = console.log;
+  console.log = () => {};
+  let threw = false;
+  try {
+    logFunction('fn','exit',cyc);
+  } catch (e) {
+    threw = true;
+  }
+  console.log = orig;
+  assert(!threw, 'Should not throw with circular object');
+});
 // =============================================================================
 // UNIT TESTS - API FUNCTIONS
 // =============================================================================


### PR DESCRIPTION
## Summary
- use `safeStringify` in `logFunction` when logging exit
- verify circular logging does not throw

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bcd209628832296f61e749b9dffa0