### PR TITLE
Handle unknown toast actions

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@
 const {
   useAsyncAction, useDropdownData, createDropdownListHook, useDropdownToggle, //(grab hook utilities)
   useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect, //(grab UI helpers)
-  showToast, toastSuccess, toastError, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem //(grab API utilities)
+  showToast, toastSuccess, toastError, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch //(grab API utilities)
 } = require('./lib/hooks'); // aggregated exports from internal modules
 
 /**
@@ -57,6 +57,7 @@ module.exports = { // expose library functions
   stopEvent,             // Event handling utility for preventing default behavior
   getToastListenerCount, // Allows tests to inspect active toast listeners
   resetToastSystem,      // Clears toast listeners between tests
+  dispatch,              // Expose dispatch for advanced control and tests
   
   // API and HTTP functionality
   apiRequest,            // Standardized HTTP request wrapper with error handling

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -574,6 +574,8 @@ const reducer = (state, action) => { // state machine controlling toast lifecycl
         ...state,
         toasts: state.toasts.filter((t) => t.id !== action.toastId),
       };
+    default:
+      return state; // return current state for unknown actions so dispatch is resilient
   }
 }; // pure function so state updates remain predictable
 
@@ -744,5 +746,6 @@ module.exports = {
   formatAxiosError,    // convert axios errors to Error
   axiosClient,         // configured axios instance
   getToastListenerCount, // test helper exposing listener set size
-  resetToastSystem      // reset listeners and state between tests
-}; 
+  resetToastSystem,     // reset listeners and state between tests
+  dispatch              // expose dispatch for tests to send custom actions
+};

--- a/test.js
+++ b/test.js
@@ -100,7 +100,7 @@ mockAxios.isAxiosError = (error) => error && error.isAxiosError === true; // mat
 const {
   useAsyncAction, useDropdownData, createDropdownListHook, useDropdownToggle,
   useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect,
-  showToast, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem
+  showToast, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch
 } = require('./index.js'); // import library after axios stub so axiosClient can be overridden
 const { buildRequestConfig, createMockResponse, handle401Error, codexRequest, executeAxiosRequest } = require('./lib/api.js'); // internal API helpers
 
@@ -854,6 +854,16 @@ runTest('toast IDs restart after resetToastSystem', () => {
   resetToastSystem(); // ensure counter resets
   const first = toast({ title: 'a' });
   assertEqual(first.id, '1', 'First toast ID after reset should be 1');
+});
+
+runTest('dispatching unknown action leaves toast state unchanged', () => {
+  resetToastSystem(); // clean slate before dispatch test
+  toast({ title: 'persist' }); // initialize state with one toast
+  const { result, unmount } = renderHook(() => useToast());
+  assertEqual(result.current.toasts.length, 1, 'Initial toast should exist');
+  TestRenderer.act(() => { dispatch({ type: 'UNKNOWN' }); });
+  assertEqual(result.current.toasts.length, 1, 'State should remain after unknown action');
+  unmount(); // remove listener
 });
 
 runTest('executeWithErrorToast displays error toast', async () => {


### PR DESCRIPTION
## Summary
- ignore unknown actions in `lib/hooks` reducer
- export `dispatch` for testing
- ensure `dispatch` is re-exported in `index.js`
- test that dispatching an unknown action doesn't change toast state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ce62d3efc83229b8eb54adaa0f00a