### PR TITLE
Enhance logging in async utility

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,10 +28,13 @@
  * @returns {Promise} Result of the operation or re-throws error
  */
 async function executeAsyncWithLogging(operation, operationName, errorHandler) {
+  logFunction(operationName, 'entry', operationName); // track start of operation for debugging
   try {
     const result = await operation();
+    logFunction(operationName, 'exit', result); // report successful result before return
     return result;
   } catch (error) {
+    logFunction(operationName, 'error', error); // record error for tracing before handling
     if (errorHandler) {
       return await errorHandler(error); // await handler so async rejections propagate
     }

--- a/test.js
+++ b/test.js
@@ -504,6 +504,21 @@ runTest('executeAsyncWithLogging awaits async handler', async () => {
   assert(caught, 'Should propagate rejection from async handler');
 });
 
+runTest('executeAsyncWithLogging logs phases', async () => {
+  const messages = [];
+  const orig = console.log;
+  console.log = (msg) => { messages.push(msg); };
+
+  await executeAsyncWithLogging(async () => 'good', 'logOp');
+  assert(messages.some(m => m.includes('logOp is running')), 'Entry log expected');
+  assert(messages.some(m => m.includes('logOp is returning')), 'Exit log expected');
+
+  messages.length = 0; // clear messages for error case
+  await executeAsyncWithLogging(async () => { throw new Error('oops'); }, 'logOpErr', () => {});
+  assert(messages.some(m => m.includes('logOpErr has run resulting in a final value of failure')), 'Error log expected');
+  console.log = orig;
+});
+
 runTest('logFunction outputs expected messages', () => {
   const messages = [];
   const orig = console.log;


### PR DESCRIPTION
## Summary
- log entry, exit, and error phases in `executeAsyncWithLogging`
- test new logging behaviour for success and failure cases

## Testing
- `npm test` *(fails: process did not finish)*

------
https://chatgpt.com/codex/tasks/task_b_684ce63297488322a68c561297bce6d5