### PR TITLE
Improve logFunction error output

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -219,7 +219,7 @@ function logFunction(functionName, phase, data) {
       console.log(`${functionName} has run resulting in a final value of ${data}`);
       break;
     case 'error':
-      console.log(`${functionName} has run resulting in a final value of failure`);
+      console.log(`${functionName} encountered error ${data}`); // include error detail for easier debugging
       break;
     default:
       console.log(`${functionName} ${phase}: ${data}`);
@@ -245,7 +245,7 @@ function withToastLogging(functionName, operation) {
       logFunction(functionName, 'exit', result);
       return result;
     } catch (err) {
-      logFunction(functionName, 'error', null);
+      logFunction(functionName, 'error', err); // pass error object for detailed logging
       throw err;
     }
   };

--- a/test.js
+++ b/test.js
@@ -512,13 +512,14 @@ runTest('logFunction outputs expected messages', () => {
   logFunction('testFn', 'entry', 'param');
   logFunction('testFn', 'exit', 'result');
   logFunction('testFn', 'completion', 'value');
-  logFunction('testFn', 'error');
+  const err = new Error('bad');
+  logFunction('testFn', 'error', err); // provide error to test logging of error details
 
   console.log = orig;
   assert(messages.some(m => m.includes('testFn is running with param')), 'Entry log expected');
   assert(messages.some(m => m.includes('testFn is returning')), 'Exit log expected');
   assert(messages.some(m => m.includes('final value of value')), 'Completion log expected');
-  assert(messages.some(m => m.includes('final value of failure')), 'Error log expected');
+  assert(messages.some(m => m.includes('encountered error') && m.includes('bad')), 'Error log expected');
 });
 
 runTest('withToastLogging wraps function and preserves errors', () => {


### PR DESCRIPTION
## Summary
- show error details in logFunction
- pass error object from withToastLogging
- ensure tests verify error log contents

## Testing
- `node test-simple.js` *(fails: apiRequest basic functionality: 500)*

------
https://chatgpt.com/codex/tasks/task_b_684ce639dc848322ac3461881b79dbc7