### PR TITLE
docs: update test setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ The library includes comprehensive test coverage:
 npm test
 ```
 
+Before running the tests, install the lightweight stubbing library used by the suite:
+
+```bash
+npm install qtests --save-dev
+```
+
+The test runner requires the `qtests/setup` module so automatic stubbing is enabled. Ensure the setup file is present or `npm test` will fail.
+
 All tests pass with 100% functional coverage including:
 - Unit tests for all hooks and utilities
 - Integration tests for hook composition


### PR DESCRIPTION
## Summary
- mention installing `qtests` before running tests
- explain the need for `qtests/setup` for `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ce655205c83228a53ae2ecbfe247a