### PR TITLE
Handle default offline response

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -148,11 +148,15 @@ async function executeAxiosRequest(axiosCall, unauthorizedBehavior, mockResponse
  * @returns {Promise} Request result or mock response
  */
 async function codexRequest(requestFn, mockResponse) { //(handle codex offline logic)
+  console.log(`codexRequest is running with ${process.env.OFFLINE_MODE}`); // log current offline mode for clarity
   try {
-    if (process.env.OFFLINE_MODE === `true`) {
-      return mockResponse; //(provide mock network result)
+    if (process.env.OFFLINE_MODE === `true`) { // branch for offline development mode
+      const offlineRes = mockResponse ?? { status: 200, data: null }; // ensure object when mock missing
+      console.log(`codexRequest is returning ${JSON.stringify(offlineRes)}`); // show offline result for debugging
+      return offlineRes; //(provide mock or default network result)
     }
     const res = await requestFn();
+    console.log(`codexRequest is returning ${JSON.stringify(res)}`); // log real return
     return res; //(pass through real network result)
   } catch (err) {
     throw err; //(rethrow request errors for caller handling)

--- a/test.js
+++ b/test.js
@@ -757,6 +757,14 @@ runTest('codexRequest offline and online behavior', async () => {
   assert(called === true, 'Request function should run online');
 });
 
+runTest('codexRequest returns default when offline without mock', async () => {
+  process.env.OFFLINE_MODE = 'true';
+  const result = await codexRequest(() => ({ data: 7 }));
+  assertEqual(result.status, 200, 'Default status should be 200');
+  assert(result.data === null, 'Default data should be null');
+  process.env.OFFLINE_MODE = 'false';
+});
+
 runTest('executeAxiosRequest integrates codexRequest and errors', async () => {
   process.env.OFFLINE_MODE = 'true';
   const resOffline = await executeAxiosRequest(() => ({ data: 5 }), 'throw', { data: { value: 5 } });
@@ -773,6 +781,14 @@ runTest('executeAxiosRequest integrates codexRequest and errors', async () => {
   }
   const nullRes = await executeAxiosRequest(() => Promise.reject(err401), 'returnNull');
   assertEqual(nullRes.data, null, 'Should return null on 401 with returnNull');
+});
+
+runTest('executeAxiosRequest returns default when offline without mock', async () => {
+  process.env.OFFLINE_MODE = 'true';
+  const res = await executeAxiosRequest(() => ({ data: 9 }), 'throw');
+  assertEqual(res.status, 200, 'Default status should be 200');
+  assert(res.data === null, 'Default data should be null');
+  process.env.OFFLINE_MODE = 'false';
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- return `{status:200,data:null}` when codex runs offline with no mock
- verify offline defaults in tests

## Testing
- `timeout 80 node test.js` *(fails: process timed out)*

------
https://chatgpt.com/codex/tasks/task_b_684ce661ce888322a132621478cbbc7a