### PR TITLE
Handle circular references in logging

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,8 @@
  * different UI libraries (shadcn/ui, Chakra UI, Material-UI, etc.).
  */
 
+const { safeStringify } = require('./validation.js'); // import JSON stringify helper with circular support
+
 /**
  * Execute an async operation with standardized error handling and logging
  * 
@@ -213,7 +215,7 @@ function logFunction(functionName, phase, data) {
       console.log(`${functionName} is running with ${data}`);
       break;
     case 'exit':
-      console.log(`${functionName} is returning ${JSON.stringify(data)}`);
+      console.log(`${functionName} is returning ${safeStringify(data)}`); // use safe stringify so logging never throws
       break;
     case 'completion':
       console.log(`${functionName} has run resulting in a final value of ${data}`);

--- a/test.js
+++ b/test.js
@@ -521,6 +521,18 @@ runTest('logFunction outputs expected messages', () => {
   assert(messages.some(m => m.includes('final value of failure')), 'Error log expected');
 });
 
+runTest('logFunction handles circular data without throwing', () => {
+  const obj = {}; obj.self = obj; // create circular reference for test
+  const messages = [];
+  const orig = console.log;
+  console.log = (msg) => { messages.push(msg); }; // capture logs to verify output
+
+  logFunction('circFn', 'exit', obj); // should not throw despite circular structure
+
+  console.log = orig;
+  assert(messages[0].includes('[Circular Reference]'), 'Should log fallback for circular object');
+});
+
 runTest('withToastLogging wraps function and preserves errors', () => {
   const calls = [];
   const wrapped = withToastLogging('demo', (t, msg) => { calls.push(msg); return 'done'; });


### PR DESCRIPTION
## Summary
- import `safeStringify` in utils
- use `safeStringify` for exit logging
- test circular reference logging

## Testing
- `node test.js | grep -n "logFunction handles circular" -n`

------
https://chatgpt.com/codex/tasks/task_b_684ce666ab8c83228f4e5c1df8de0691