### PR TITLE
Use toastError helper in dropdown hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Generic React hook for managing dropdown state with loading and error handling.
 
 **Parameters:**
 - `fetcher` (Function): Async function that returns array data
-- `toast` (Object): Toast instance for error notifications
+- `toast` (Function): Toast function for error notifications
 - `user` (Object): User object that triggers data fetch when available
 
 **Returns:** Object - `{items, isLoading, fetchData}`
@@ -71,7 +71,7 @@ Factory function that creates typed dropdown hooks.
 **Parameters:**
 - `fetcher` (Function): Async function that returns array data
 
-**Returns:** Function - Custom hook that accepts `(toast, user)` parameters
+**Returns:** Function - Custom hook that accepts `(toast, user)` parameters, where `toast` is a toast function
 
 ### useDropdownToggle()
 React hook for managing dropdown open/close state.

--- a/enhanced-tests.js
+++ b/enhanced-tests.js
@@ -324,7 +324,7 @@ runTest('useEditForm setField updates correctly', () => {
 
 runTest('useDropdownData handles fetcher errors gracefully', () => {
   const errorFetcher = async () => { throw new Error('Fetch failed'); };
-  const mockToast = { error: () => {} };
+  const mockToast = () => {}; // simplified toast function
   const { result } = renderHook(() => useDropdownData(errorFetcher, mockToast, { id: 'user' }));
   
   assert(Array.isArray(result.current.items), 'Should return empty items array on error');

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -186,7 +186,7 @@ function useAsyncAction(asyncFn, options) {
  * @param {Object} user - User object to trigger fetch when available
  * @returns {Object} Returns {items, isLoading, fetchData}
  */
-function useDropdownData(fetcher, toast, user) {
+function useDropdownData(fetcher, toastFn, user) {
   if (!isFunction(fetcher)) { throw new Error('useDropdownData requires a function for `fetcher` parameter'); } // early validation prevents runtime errors
   // Initialize with empty array to ensure components can safely map over items immediately
   const [items, setItems] = useState([]);
@@ -198,10 +198,10 @@ function useDropdownData(fetcher, toast, user) {
       const data = await fetcher();
       setItems(data);
     } catch (error) {
-      // Guard against non-function toast.error so the hook doesn't throw at runtime
+      // Guard against non-function toastFn so the hook doesn't throw at runtime
       // Toast integration is optional and should fail silently when misconfigured
-      if (toast && typeof toast.error === 'function') { // ensure error handler is callable
-        toast.error(`Failed to load data.`); // surface failure via toast notification
+      if (typeof toastFn === 'function') { // verify toast function before calling
+        toastError(toastFn, `Failed to load data.`); // standardized error toast
       }
     } finally {
       setIsLoading(false);
@@ -214,7 +214,7 @@ function useDropdownData(fetcher, toast, user) {
     if (user) {
       fetchData();
     }
-  }, [user, fetcher, toast]); // ensure refetch when dependencies change
+  }, [user, fetcher, toastFn]); // ensure refetch when dependencies change
 
   return { items, isLoading, fetchData };
 }
@@ -245,9 +245,9 @@ function createDropdownListHook(fetcher) {
   
   // Return a custom hook that closes over the fetcher function
   // This creates a specialized version of useDropdownData for a specific data source
-  function useList(toast, user) {
+  function useList(toastFn, user) {
     // Delegate to the generic useDropdownData hook with the pre-bound fetcher
-    const result = useDropdownData(fetcher, toast, user);
+    const result = useDropdownData(fetcher, toastFn, user);
     return result;
   }
   

--- a/test.js
+++ b/test.js
@@ -1001,7 +1001,7 @@ runTest('createDropdownListHook integration with useDropdownData', () => {
   assert(typeof useCustomDropdown === 'function', 'Should create hook function');
   
   // Mock toast and user for testing
-  const mockToast = { error: () => {} };
+  const mockToast = () => {}; // single function to fit new hook signature
   const mockUser = { id: 'test-user' };
   
   const { result } = renderHook(() => useCustomDropdown(mockToast, mockUser)); // Render hook with React renderer
@@ -1032,19 +1032,19 @@ runTest('useDropdownData refetches when toast changes', async () => {
 
   const { rerender } = renderHook(
     (p) => useDropdownData(fetcher, p.toast, { id: 'u2' }),
-    { toast: { error: () => {} } }
+    { toast: () => {} }
   );
   await TestRenderer.act(async () => { await Promise.resolve(); });
   assertEqual(calls, 1, 'Initial fetch should run once');
 
-  rerender({ toast: { error: () => {} } });
+  rerender({ toast: () => {} });
   await TestRenderer.act(async () => { await Promise.resolve(); });
   assertEqual(calls, 2, 'Fetch should run again when toast instance changes');
 });
 
 runTest('useDropdownData skips toast error when not a function', async () => {
   const fetcher = async () => { throw new Error('fail'); };
-  const { result } = renderHook(() => useDropdownData(fetcher, { error: 'text' }, { id: 'u3' }));
+  const { result } = renderHook(() => useDropdownData(fetcher, 'text', { id: 'u3' }));
   await TestRenderer.act(async () => { await result.current.fetchData(); });
   assert(Array.isArray(result.current.items), 'Hook should not crash on invalid toast');
   assert(result.current.isLoading === false, 'Loading state resets after failure');
@@ -1103,7 +1103,7 @@ runTest('useDropdownData and useToastAction integration sequence', async () => {
 
   function useCombo() {
     const toastStore = useToast();
-    const dropdown = useDropdownData(mockFetcher, { error: (msg) => showToast(toastStore.toast, msg, 'Error', 'destructive') }, null);
+    const dropdown = useDropdownData(mockFetcher, (msg) => showToast(toastStore.toast, msg, 'Error', 'destructive'), null); // pass toast function
     const [trigger] = useToastAction(dropdown.fetchData, 'Loaded');
     return { dropdown, trigger };
   }


### PR DESCRIPTION
## Summary
- use `toastError` in `useDropdownData`
- adjust dropdown hook signature to accept a toast function
- update `createDropdownListHook` and related tests
- document new parameter type in README

## Testing
- `npm test` *(fails: Test 39 due to environment issues)*
- `node test-simple.js` *(fails: apiRequest basic functionality)*

------
https://chatgpt.com/codex/tasks/task_b_684ce6732ff08322a6e4188d73259f93