### PR TITLE
Add qtests fallback and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ The library includes comprehensive test coverage:
 # Run test suite
 npm test
 ```
+Before running the tests ensure `qtests` is installed by executing `npm install`. The `test-setup` script falls back to local stubs when `qtests` is not available.
 
 All tests pass with 100% functional coverage including:
 - Unit tests for all hooks and utilities

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,15 @@
+// Attempt to load qtests setup so axios and winston stubs exist for tests
+let qtestsAvailable = true; // track presence of qtests module for reporting
+try { require('qtests/setup'); } catch (error) {
+  qtestsAvailable = false; // qtests missing so we fall back to simple mocks
+  console.log('test-setup: using local stubs because qtests is missing'); // log fallback so devs know why
+  const Module = require('module'); // node module loader reference
+  const axiosStub = { get: async () => ({}), post: async () => ({}) }; // minimal axios stub for HTTP calls
+  const winstonStub = { createLogger: () => ({ info: () => {}, error: () => {}, debug: () => {} }), format: { combine: () => {}, timestamp: () => {}, json: () => {}, printf: () => {}, errors: () => {}, splat: () => {} }, transports: { Console: function () {}, File: function () {} } }; // winston stub with no-op methods
+  const originalLoad = Module._load; // keep original loader to call for other modules
+  Module._load = function patchedLoad(request, parent, isMain) { // replace loader to intercept axios/winston
+    if (request === 'axios') { return axiosStub; } else if (request === 'winston') { return winstonStub; }
+    return originalLoad(request, parent, isMain); // defer to original for everything else
+  }; // loader patched so tests run without qtests
+}
+module.exports = { qtestsAvailable }; // export flag for potential debugging

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-require('qtests/setup'); // initialize qtests stubs before other imports
+require('./test-setup'); // ensure qtests or fallback stubs
 
 /**
  * Comprehensive Test Suite for React Hooks Utility Library


### PR DESCRIPTION
## Summary
- ensure tests load `qtests/setup` or fallback stubs
- document `qtests` requirement for running tests

## Testing
- `npm test` *(fails: incomplete output)*

------
https://chatgpt.com/codex/tasks/task_b_684ce67791788322b24c794a7b130aaf