### PR TITLE
Fix async error transforms

### DIFF
--- a/lib/errorHandling.js
+++ b/lib/errorHandling.js
@@ -16,7 +16,7 @@
  * 
  * @param {Function} fn - Function to execute
  * @param {string} functionName - Name for logging purposes
- * @param {Function} errorTransform - Optional error transformation function
+ * @param {Function} errorTransform - Optional error transformation function; can return Error or Promise resolving to Error //(note async transforms allowed)
  * @returns {*} Function result or throws transformed error
  */
 async function executeWithErrorHandling(fn, functionName, errorTransform) {
@@ -26,7 +26,11 @@ async function executeWithErrorHandling(fn, functionName, errorTransform) {
   } catch (error) { // standard error path
     
     if (errorTransform && typeof errorTransform === 'function') {
-      throw errorTransform(error);
+      const transformed = errorTransform(error); //(capture potential promise)
+      if (transformed && typeof transformed.then === 'function') { //(detect promise to support async)
+        throw await transformed; //(await promise and rethrow resolved Error)
+      }
+      throw transformed; //(rethrow sync transformed Error)
     }
     
     throw error;

--- a/test.js
+++ b/test.js
@@ -1241,6 +1241,14 @@ runTest('executeWithErrorHandling manages async operations', async () => {
   } catch (e) {
     assert(e.message === 'wrapped', 'Should throw transformed error');
   }
+
+  const asyncTransform = async () => { await Promise.resolve(); return new Error('async'); }; //(simulate async transform)
+  try {
+    await executeWithErrorHandling(errFn, 'errAsyncTrans', asyncTransform); //(call with async transform)
+    throw new Error('should have thrown');
+  } catch (e) {
+    assert(e.message === 'async', 'Should await transformed error');
+  }
 });
 
 runTest('executeSyncWithErrorHandling manages sync operations', () => {


### PR DESCRIPTION
## Summary
- handle promises in `executeWithErrorHandling`
- test async `errorTransform` behavior

## Testing
- `npm test` *(fails: process stalled before completion)*

------
https://chatgpt.com/codex/tasks/task_b_684ce687ec048322b0c74bbe0002d195