### PR TITLE
Improve toast fallback in useDropdownData

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Generic React hook for managing dropdown state with loading and error handling.
 
 **Parameters:**
 - `fetcher` (Function): Async function that returns array data
-- `toast` (Object): Toast instance for error notifications
+ - `toast` (Object|Function): Toast instance for error notifications. If `toast.error` is missing but `toast` is a function, the hook falls back to that function.
 - `user` (Object): User object that triggers data fetch when available
 
 **Returns:** Object - `{items, isLoading, fetchData}`

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -198,10 +198,12 @@ function useDropdownData(fetcher, toast, user) {
       const data = await fetcher();
       setItems(data);
     } catch (error) {
-      // Guard against non-function toast.error so the hook doesn't throw at runtime
-      // Toast integration is optional and should fail silently when misconfigured
-      if (toast && typeof toast.error === 'function') { // ensure error handler is callable
+      // Guard against invalid toast implementations so the hook fails gracefully
+      // Prefer built-in toast.error when available, otherwise fallback to base toast
+      if (toast && typeof toast.error === 'function') { // use library's error method when present
         toast.error(`Failed to load data.`); // surface failure via toast notification
+      } else if (typeof toast === 'function') { // fallback to generic toast when only function provided
+        toastError(toast, `Failed to load data.`); // reuse standard error helper for consistency
       }
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- fallback to generic toast if `toast.error` not available
- document toast fallback logic

## Testing
- `npm test` *(fails: Test 39 and after not executed)*
- `node test-simple.js` *(fails: apiRequest basic functionality: 500)*

------
https://chatgpt.com/codex/tasks/task_b_684ce68d2dcc8322bef21bc9947d19dd