### PR TITLE
Replace custom stringify with safe-json-stringify

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,7 +15,7 @@
  * different UI libraries (shadcn/ui, Chakra UI, Material-UI, etc.).
  */
 
-const { safeStringify } = require('./validation.js'); // import JSON stringify helper with circular support
+const { safeStringify } = require('./validation.js'); // import safe-json-stringify wrapper for consistent logging
 
 /**
  * Execute an async operation with standardized error handling and logging

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -38,17 +38,9 @@ function isObject(value) {
  * for circular references, used across multiple modules.
  * 
  * @param {*} value - Value to stringify
- * @param {string} fallback - Fallback string if JSON.stringify fails
- * @returns {string} JSON string or fallback
+ * @returns {string} JSON string with [Circular] markers
  */
-function safeStringify(value, fallback = '[Circular Reference]') {
-  try {
-    const str = JSON.stringify(value); // convert value to string; may return undefined for unsupported types
-    return str === undefined ? fallback : str; // use fallback when JSON.stringify yields undefined
-  } catch (error) {
-    return fallback; // return fallback when JSON.stringify throws
-  }
-}
+const safeStringify = require('safe-json-stringify'); // use third-party module to avoid custom cycle logic
 
 /**
  * Check if an error is an axios error with a specific status
@@ -67,6 +59,6 @@ function isAxiosErrorWithStatus(error, status) {
 module.exports = {
   isFunction,            // type guard for functions
   isObject,              // type guard for plain objects
-  safeStringify,         // JSON stringify with fallback
+  safeStringify,         // wrapped safe-json-stringify for circular refs
   isAxiosErrorWithStatus // axios error checker
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@types/node": "^22.15.31",
         "axios": "^1.9.0",
         "qtests": "^1.0.4",
-        "react": "^19.1.0"
+        "react": "^19.1.0",
+        "safe-json-stringify": "^1.2.0"
       },
       "devDependencies": {
         "react-test-renderer": "^19.1.0"
@@ -373,6 +374,12 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -611,6 +618,11 @@
         "react-is": "^19.1.0",
         "scheduler": "^0.26.0"
       }
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg=="
     },
     "scheduler": {
       "version": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@types/node": "^22.15.31",
     "axios": "^1.9.0",
     "qtests": "^1.0.4",
-    "react": "^19.1.0"
+    "react": "^19.1.0",
+    "safe-json-stringify": "^1.2.0"
   },
   "devDependencies": {
     "react-test-renderer": "^19.1.0"

--- a/test.js
+++ b/test.js
@@ -600,17 +600,17 @@ runTest('safeStringify handles circular references gracefully', () => {
   obj.self = obj; // create circular reference
 
   const result = safeStringify(obj);
-  assertEqual(result, '[Circular Reference]', 'Should return fallback for circular object');
+  assertEqual(result, '{"name":"test","self":"[Circular]"}', 'Should mark circular reference in output');
 
   const normal = { a: 1 };
   assertEqual(safeStringify(normal), JSON.stringify(normal), 'Should stringify non-circular objects');
 });
 
-runTest('safeStringify(undefined) returns fallback string', () => {
+runTest('safeStringify(undefined) returns literal undefined string', () => {
   assertEqual(
     safeStringify(undefined),
-    '[Circular Reference]',
-    'Should return fallback when JSON.stringify returns undefined'
+    'undefined',
+    'Should return "undefined" for undefined input'
   );
 });
 


### PR DESCRIPTION
## Summary
- add `safe-json-stringify` dependency
- use `safe-json-stringify` inside validation utilities
- update utils to import the new wrapper
- adjust tests for new string output

## Testing
- `npm test` *(fails: EPIPE / act warnings)*

------
https://chatgpt.com/codex/tasks/task_b_684cfe8f7d848322934cf50415e46745