### PR TITLE
Refactor toast id generation

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -18,6 +18,7 @@
 const { useState, useCallback, useEffect, useMemo } = require('react'); // add useMemo for stable callback objects
 const { showToast, toastSuccess, toastError } = require('./utils');
 const { isFunction } = require('./validation'); // import type guard for parameter validation
+const crypto = require('crypto'); // node crypto for UUID generation
 
 /**
  * Helper function for managing loading state with async operations
@@ -478,25 +479,14 @@ const actionTypes = {
 };
 
 /**
- * Global counter for generating unique toast IDs
- * 
- * Simple incrementing counter that wraps at MAX_SAFE_INTEGER to prevent overflow.
- * Using a global counter ensures uniqueness across all toast instances.
- */
-let count = 0;
-
-/**
  * Generate unique toast identifiers
- * 
- * Creates sequential IDs for toasts. The modulo operation prevents integer overflow
- * in long-running applications, though it's unlikely to be reached in practice.
- * 
+ *
+ * Uses crypto.randomUUID to ensure globally unique IDs without tracking a counter.
+ * This approach avoids potential collisions and removes global mutable state.
+ *
  * @returns {string} Unique identifier for a toast
  */
-function genId() {
-  count = (count + 1) % Number.MAX_SAFE_INTEGER;
-  return count.toString();
-}
+function genId() { return crypto.randomUUID(); } // random UUID for reliable uniqueness
 
 /**
  * Global storage for toast removal timeouts
@@ -601,7 +591,7 @@ function dispatch(action) { // notify subscribers whenever toast state changes
 /**
  * Create a new toast in the global store
  *
- * Each toast receives a sequential id from genId() so updates and dismisses
+ * Each toast receives a random id from genId() so updates and dismisses
  * can target the specific toast later. The function dispatches an ADD_TOAST
  * action and exposes helpers for modification.
  *
@@ -667,7 +657,6 @@ function resetToastSystem() {
   memoryState = { toasts: [] }; // reset toast state
   toastTimeouts.forEach((timeout) => clearTimeout(timeout)); // cancel pending removals so no stray timers fire
   toastTimeouts.clear(); // drop handles to fully reset map
-  count = 0; // reset id counter so toast ids restart from 1 after system reset
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -894,10 +894,11 @@ runTest('toast system memory management', () => {
   assert(typeof useToast === 'function', 'useToast function should exist for memory management');
 });
 
-runTest('toast IDs restart after resetToastSystem', () => {
-  resetToastSystem(); // ensure counter resets
+runTest('toast IDs remain valid after resetToastSystem', () => {
+  resetToastSystem(); // ensure clean state
   const first = toast({ title: 'a' });
-  assertEqual(first.id, '1', 'First toast ID after reset should be 1');
+  assert(typeof first.id === 'string', 'ID should be string after reset');
+  assertEqual(first.id.length, 36, 'ID should use UUID format');
 });
 
 runTest('dispatching unknown action leaves toast state unchanged', () => {


### PR DESCRIPTION
## Summary
- drop sequential counter for toast ids in `lib/hooks.js`
- use crypto.randomUUID for more reliable unique ids
- ensure tests accept UUID formatted ids

## Testing
- `node test.js` *(fails: An update to TestComponent...)*

------
https://chatgpt.com/codex/tasks/task_b_684cfea368cc8322a5c60d6197d60aa9