### PR TITLE
Use nanoid for toast identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ React hook for handling authentication-based redirects.
 ### toast(props)
 Standalone toast function for creating notifications.
 
+Each toast is assigned a unique id generated with `nanoid()` so it can be
+updated or dismissed programmatically.
+
 **Parameters:**
 - `props` (Object): Toast configuration object
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -18,6 +18,7 @@
 const { useState, useCallback, useEffect, useMemo } = require('react'); // add useMemo for stable callback objects
 const { showToast, toastSuccess, toastError } = require('./utils');
 const { isFunction } = require('./validation'); // import type guard for parameter validation
+const { nanoid } = require('nanoid'); // generate collision-resistant ids for toasts
 
 /**
  * Helper function for managing loading state with async operations
@@ -478,24 +479,16 @@ const actionTypes = {
 };
 
 /**
- * Global counter for generating unique toast IDs
- * 
- * Simple incrementing counter that wraps at MAX_SAFE_INTEGER to prevent overflow.
- * Using a global counter ensures uniqueness across all toast instances.
- */
-let count = 0;
-
-/**
- * Generate unique toast identifiers
- * 
- * Creates sequential IDs for toasts. The modulo operation prevents integer overflow
- * in long-running applications, though it's unlikely to be reached in practice.
- * 
+ * Generate unique toast identifiers using nanoid
+ *
+ * nanoid provides URL-friendly, collision-resistant IDs so we no longer need a
+ * manual counter. This simplifies the resetToastSystem logic and removes any
+ * risk of integer overflow.
+ *
  * @returns {string} Unique identifier for a toast
  */
 function genId() {
-  count = (count + 1) % Number.MAX_SAFE_INTEGER;
-  return count.toString();
+  return nanoid();
 }
 
 /**
@@ -601,7 +594,7 @@ function dispatch(action) { // notify subscribers whenever toast state changes
 /**
  * Create a new toast in the global store
  *
- * Each toast receives a sequential id from genId() so updates and dismisses
+ * Each toast receives a unique id from genId() so updates and dismisses
  * can target the specific toast later. The function dispatches an ADD_TOAST
  * action and exposes helpers for modification.
  *
@@ -667,7 +660,6 @@ function resetToastSystem() {
   memoryState = { toasts: [] }; // reset toast state
   toastTimeouts.forEach((timeout) => clearTimeout(timeout)); // cancel pending removals so no stray timers fire
   toastTimeouts.clear(); // drop handles to fully reset map
-  count = 0; // reset id counter so toast ids restart from 1 after system reset
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.80.6",
         "@types/node": "^22.15.31",
         "axios": "^1.9.0",
+        "nanoid": "^5.0.2",
         "qtests": "^1.0.4",
         "react": "^19.1.0"
       },
@@ -327,6 +328,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -576,6 +595,11 @@
       "requires": {
         "mime-db": "1.52.0"
       }
+    },
+    "nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="
     },
     "proxy-from-env": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-query": "^5.80.6",
     "@types/node": "^22.15.31",
     "axios": "^1.9.0",
+    "nanoid": "^5.0.2",
     "qtests": "^1.0.4",
     "react": "^19.1.0"
   },

--- a/test.js
+++ b/test.js
@@ -895,9 +895,9 @@ runTest('toast system memory management', () => {
 });
 
 runTest('toast IDs restart after resetToastSystem', () => {
-  resetToastSystem(); // ensure counter resets
+  resetToastSystem(); // ensure system is cleared before generating new ids
   const first = toast({ title: 'a' });
-  assertEqual(first.id, '1', 'First toast ID after reset should be 1');
+  assert(typeof first.id === 'string' && first.id.length > 0, 'First toast ID should be string after reset');
 });
 
 runTest('dispatching unknown action leaves toast state unchanged', () => {


### PR DESCRIPTION
## Summary
- generate toast IDs with `nanoid`
- document nanoid usage in README
- update test to check for string ID after reset
- add nanoid dependency

## Testing
- `npm test` *(fails to show full output due to act warnings but no errors seen)*

------
https://chatgpt.com/codex/tasks/task_b_684cfeae8f2c8322b9f5d09bc0d9537e