### PR TITLE
Remove deprecated API helpers

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -52,41 +52,8 @@ const axiosClient = axios.create({
 });
 
 /**
- * Helper function for building request configuration objects
- * 
- * Standardizes request configuration across different API functions,
- * reducing duplication of URL, method, and data parameter handling.
- * 
- * @param {string} url - Request URL
- * @param {string} method - HTTP method
- * @param {*} data - Request body data
- * @returns {Object} Axios request configuration
- */
-function buildRequestConfig(url, method, data) { // standardizes axios request config for reuse
-  return { url, method, data }; // package config fields together
-} //(end buildRequestConfig) // corrected closing comment
-
-/**
- * Helper function for creating mock responses based on URL patterns
- * 
- * Centralizes the mock response logic used across different API functions,
- * reducing duplication of mock response creation patterns.
- * 
- * @param {string} url - Request URL to generate mock for
- * @param {string} method - HTTP method
- * @param {*} data - Request data
- * @returns {Object} Mock response object
- */
-function createMockResponse(url, method, data) {
-  return {
-    status: 200,
-    data: { success: true, url, method, requestData: data, mocked: true }
-  };
-}
-
-/**
  * Helper function for handling 401 errors consistently
- * 
+ *
  * Standardizes 401 error handling logic used across multiple functions,
  * supporting both returnNull and throw behaviors.
  * 
@@ -266,8 +233,6 @@ const queryClient = new QueryClient({ // shared React Query client for the app
 });
 
 module.exports = { //(expose API helpers)
-  buildRequestConfig,  // create axios config consistently
-  createMockResponse,  // produce standardized mock responses
   handle401Error,      // unify 401 status handling
   codexRequest,        // offline development wrapper
   executeAxiosRequest, // axios wrapper with error handling

--- a/test.js
+++ b/test.js
@@ -102,7 +102,7 @@ const {
   useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect,
   showToast, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch
 } = require('./index.js'); // import library after axios stub so axiosClient can be overridden
-const { buildRequestConfig, createMockResponse, handle401Error, codexRequest, executeAxiosRequest } = require('./lib/api.js'); // internal API helpers
+const { handle401Error, codexRequest, executeAxiosRequest } = require('./lib/api.js'); // internal API helpers without config helpers
 
 // Direct imports for internal utilities under test
 const { executeAsyncWithLogging, logFunction, withToastLogging } = require('./lib/utils.js'); // test logging helpers
@@ -747,21 +747,6 @@ runTest('queryClient configuration and methods', () => {
   assert(defaultOptions.queries.refetchOnWindowFocus === false, 'Should disable window focus refetch');
 });
 
-runTest('buildRequestConfig returns correct structure', () => {
-  const cfg = buildRequestConfig('/api/x', 'PUT', { a: 1 });
-  assertEqual(cfg.url, '/api/x', 'URL should match');
-  assertEqual(cfg.method, 'PUT', 'Method should match');
-  assertEqual(cfg.data.a, 1, 'Data should match');
-});
-
-runTest('createMockResponse produces expected mock data', () => {
-  const mock = createMockResponse('/api/x', 'POST', { b: 2 });
-  assertEqual(mock.status, 200, 'Status should be 200');
-  assert(mock.data.mocked === true, 'Should flag as mocked');
-  assertEqual(mock.data.url, '/api/x', 'URL should match');
-  assertEqual(mock.data.method, 'POST', 'Method should match');
-  assertEqual(mock.data.requestData.b, 2, 'Request data should match');
-});
 
 runTest('handle401Error logic across behaviors', () => {
   const err401 = { isAxiosError: true, response: { status: 401 } };


### PR DESCRIPTION
## Summary
- delete `buildRequestConfig` and `createMockResponse`
- adjust exports in `lib/api.js`
- clean test imports and remove helper tests

## Testing
- `node test.js` *(fails to finish within the environment)*
- `node test-simple.js`

------
https://chatgpt.com/codex/tasks/task_b_684cfeb4ce8883229fa2eeca72cc6352