### PR TITLE
Fix redundant JSON stringify

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 
 const { QueryClient } = require("@tanstack/react-query"); // React Query core client
 const axios = require("axios"); // HTTP client used for API requests
+const { safeStringify } = require('./validation'); // safe-json-stringify wrapper for consistent logging
 
 /**
  * API Module: Centralized HTTP Request Management and React Query Integration
@@ -119,11 +120,11 @@ async function codexRequest(requestFn, mockResponse) { //(handle codex offline l
   try {
     if (process.env.OFFLINE_MODE === `true`) { // branch for offline development mode
       const offlineRes = mockResponse ?? { status: 200, data: null }; // ensure object when mock missing
-      console.log(`codexRequest is returning ${JSON.stringify(offlineRes)}`); // show offline result for debugging
+      console.log(`codexRequest is returning ${safeStringify(offlineRes)}`); // show offline result for debugging
       return offlineRes; //(provide mock or default network result)
     }
     const res = await requestFn();
-    console.log(`codexRequest is returning ${JSON.stringify(res)}`); // log real return
+    console.log(`codexRequest is returning ${safeStringify(res)}`); // log real return
     return res; //(pass through real network result)
   } catch (err) {
     throw err; //(rethrow request errors for caller handling)
@@ -140,20 +141,8 @@ function formatAxiosError(err) { //(normalize axios error)
     if (axios.isAxiosError(err)) { //(normalize axios error)
       const status = err.response?.status ?? 500;
       const data = err.response?.data ?? err.message;
-      let dataString;
-      
-      if (typeof data === 'string') {
-        dataString = data;
-      } else {
-        try {
-          dataString = JSON.stringify(data);
-        } catch (circularError) {
-          // Handle circular references by creating a safe representation
-          dataString = `[Object with circular reference: ${Object.prototype.toString.call(data)}]`;
-        }
-      }
-      
-      const error = new Error(`${status}: ${dataString}`);
+      const dataString = typeof data === 'string' ? data : safeStringify(data); // use module for circular refs
+      const error = new Error(`${status}: ${dataString}`); // preserve status and payload
       return error;
     }
     const wrapped = new Error(String(err)); //(wrap non-Axios error to ensure Error instance)


### PR DESCRIPTION
## Summary
- replace manual JSON stringify logic with safe-json-stringify wrapper
- apply safe stringify in codexRequest logging and formatAxiosError

## Testing
- `npm test` *(fails: Invalid package.json)*
- `node test.js` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_b_684e10c777cc8322b61f3893962f402a