### PR TITLE
Refactor hooks to use React Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The library provides production-ready React hooks with comprehensive error handl
 ## Hooks API
 
 ### useAsyncAction(asyncFn, options)
-React hook for handling async actions with loading state and error handling.
+React hook for handling async actions with loading state using React Query's mutation system.
 
 **Parameters:**
 - `asyncFn` (Function): The async function to execute
@@ -56,7 +56,7 @@ const [fetchData, isLoading] = useAsyncAction(
 ```
 
 ### useDropdownData(fetcher, toast, user)
-Generic React hook for managing dropdown state with loading and error handling.
+Generic React hook for managing dropdown state via a React Query `useQuery` call.
 
 **Parameters:**
 - `fetcher` (Function): Async function that returns array data

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -16,6 +16,7 @@
  * - Error handling and loading states as first-class concerns
  */
 const { useState, useCallback, useEffect, useMemo } = require('react'); // add useMemo for stable callback objects
+const { useMutation, useQuery } = require('@tanstack/react-query'); // use React Query hooks for async operations
 const { showToast, toastSuccess, toastError } = require('./utils');
 const { isFunction } = require('./validation'); // import type guard for parameter validation
 
@@ -142,30 +143,15 @@ function useCallbackWithErrorHandling(operation, options, deps) {
  * @returns {Array} Returns [run, isLoading] tuple
  */
 function useAsyncAction(asyncFn, options) {
-  const [isLoading, setIsLoading] = useState(false);
+  const mutation = useMutation({
+    mutationFn: async (...args) => asyncFn(...args),
+    onSuccess: async (res) => { await options?.onSuccess?.(res); },
+    onError: async (err) => { await options?.onError?.(err); }
+  }, queryClient);
 
-  // useCallback ensures the returned function has a stable reference across re-renders
-  // This prevents child components from re-rendering unnecessarily when they depend on this function
-  const run = useCallback(async (...args) => {
-    try {
-      setIsLoading(true);
-      const result = await asyncFn(...args);
-      // Optional chaining used here because callbacks are optional
-      // onSuccess is called with the result, allowing for data processing or UI updates
-      await options?.onSuccess?.(result); // await to support async callbacks propagating failures
-      return result;
-    } catch (error) {
-      // onError callback allows for centralized error handling (e.g., showing toasts)
-      await options?.onError?.(error); // await async error handling to bubble up
-      // Re-throw to allow calling code to handle the error if needed
-      throw error;
-    } finally {
-      // Finally block ensures loading state is always cleared, even if callbacks throw
-      setIsLoading(false);
-    }
-  }, [asyncFn, options]); // Dependencies ensure the callback updates when these change
+  const run = useCallback((...args) => mutation.mutateAsync(...args), [mutation]);
 
-  return [run, isLoading];
+  return [run, mutation.isPending];
 }
 
 /**
@@ -191,36 +177,22 @@ function useAsyncAction(asyncFn, options) {
  * @returns {Object} Returns {items, isLoading, fetchData}
  */
 function useDropdownData(fetcher, toastFn, user) {
-  if (!isFunction(fetcher)) { throw new Error('useDropdownData requires a function for `fetcher` parameter'); } // early validation prevents runtime errors
-  // Initialize with empty array to ensure components can safely map over items immediately
-  const [items, setItems] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
+  if (!isFunction(fetcher)) { throw new Error('useDropdownData requires a function for `fetcher` parameter'); }
+  const queryKey = useMemo(() => ['dropdown', fetcher], [fetcher]);
 
-  async function fetchData() {
-    try {
-      setIsLoading(true);
-      const data = await fetcher();
-      setItems(data);
-    } catch (error) {
-      // Guard against non-function toastFn so the hook doesn't throw at runtime
-      // Toast integration is optional and should fail silently when misconfigured
-      if (typeof toastFn === 'function') { // verify toast function before calling
-        toastError(toastFn, `Failed to load data.`); // standardized error toast
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }
+  const { data, isPending } = useQuery({
+    queryKey,
+    queryFn: fetcher,
+    enabled: !!user,
+    retry: false,
+    onError: () => { if (typeof toastFn === 'function') { toastError(toastFn, `Failed to load data.`); } }
+  }, queryClient);
 
-  // Effect runs when user changes - this implements the pattern where
-  // we only fetch data after user authentication is confirmed
-  useEffect(() => { // redirect when condition changes
-    if (user) {
-      fetchData();
-    }
-  }, [user, fetcher, toastFn]); // ensure refetch when dependencies change
+  const fetchData = useCallback(() => queryClient.fetchQuery({ queryKey, queryFn: fetcher }), [queryKey, fetcher]);
 
-  return { items, isLoading, fetchData };
+  useEffect(() => { if (user) { fetchData(); } }, [user, fetchData, toastFn]);
+
+  return { items: data ?? [], isLoading: isPending, fetchData };
 }
 
 /**


### PR DESCRIPTION
## Summary
- migrate `useAsyncAction` to use `useMutation`
- move dropdown fetching to React Query with `useQuery`
- document updated hooks

## Testing
- `node test.js` *(fails: TestComponent warnings)*
- `node test-simple.js` *(fails: apiRequest basic functionality)*

------
https://chatgpt.com/codex/tasks/task_b_684e701ab8048322806b8733066283c2