### PR TITLE
Remove genId helper and update docs

### DIFF
--- a/attached_assets/Pasted-import-as-React-from-react-import-React-for-hook-APIs-Centralized-toast-management-for-c-1749350963858_1749350963858.txt
+++ b/attached_assets/Pasted-import-as-React-from-react-import-React-for-hook-APIs-Centralized-toast-management-for-c-1749350963858_1749350963858.txt
@@ -31,12 +31,7 @@ const actionTypes = {
   REMOVE_TOAST: "REMOVE_TOAST",
 } as const
 
-let count = 0
-
-function genId() {
-  count = (count + 1) % Number.MAX_SAFE_INTEGER
-  return count.toString()
-}
+const { nanoid } = require('nanoid')
 
 type ActionType = typeof actionTypes
 
@@ -149,7 +144,7 @@ function dispatch(action: Action) { //(notify listeners with updated state)
 type Toast = Omit<ToasterToast, "id">
 
 function toast({ ...props }: Toast) { //(create new toast and return controls)
-  const id = genId()
+  const id = nanoid()
 
   const update = (props: ToasterToast) =>
     dispatch({

--- a/bug-analysis.md
+++ b/bug-analysis.md
@@ -126,19 +126,16 @@ const showToast = withToastLogging('showToast', function(toast, message, title, 
 **Fix**: Add type checking for critical parameters
 
 #### Issue: Potential integer overflow in toast ID generation
-**Location**: `lib/hooks.js:509-512`
+**Location**: `lib/hooks.js`
 **Severity**: VERY LOW
-**Description**: While modulo operation prevents true overflow, ID collision is theoretically possible.
+**Description**: Previous versions used a simple counter for toast IDs which could theoretically overflow.
 
 ```javascript
-function genId() {
-  count = (count + 1) % Number.MAX_SAFE_INTEGER;
-  return count.toString();
-}
+const id = nanoid();
 ```
 
-**Impact**: Extremely unlikely ID collision after 9+ quadrillion toasts
-**Status**: Not a practical concern
+**Impact**: Collision risk eliminated with nanoid's randomness
+**Status**: Resolved by using nanoid()
 
 ### 5. Performance and Optimization Issues
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -428,24 +428,8 @@ const actionTypes = {
 
 
 /**
- * Generate unique toast identifiers using nanoid
- *
- * nanoid provides URL-friendly, collision-resistant IDs so we no longer need a
- * manual counter. This simplifies the resetToastSystem logic and removes any
- * risk of integer overflow.
- *
- * @returns {string} Unique identifier for a toast
- */
-function genId() {
-  return nanoid();
-}
-
-// nanoid provides cryptographically strong IDs, avoiding global counters for simplicity
-
-
-/**
  * Global storage for toast removal timeouts
- * 
+ *
  * Maps toast IDs to their timeout handles, allowing for:
  * 1. Canceling removal if toast is updated before timeout
  * 2. Preventing duplicate timeouts for the same toast
@@ -546,8 +530,6 @@ function dispatch(action) { // notify subscribers whenever toast state changes
 /**
  * Create a new toast in the global store
  *
-
- * Each toast receives a unique id from genId() so updates and dismisses
 
  * Each toast receives a unique id from nanoid() so updates and dismisses
 


### PR DESCRIPTION
## Summary
- remove obsolete `genId` helper
- tweak toast comments to reference `nanoid`
- document nanoid fix in bug analysis
- update example asset to use `nanoid`

## Testing
- `node test-simple.js` *(fails: apiRequest basic functionality: 500)*

------
https://chatgpt.com/codex/tasks/task_b_684e702879fc8322ba60b608b60866a5