### PR TITLE
Extend withToastLogging documentation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -233,11 +233,20 @@ function logFunction(functionName, phase, data) {
 
 /**
  * Higher-order function wrapper for consistent logging across toast functions
- * 
+ *
  * This reduces the repetitive try-catch-log pattern while maintaining individual
  * function clarity. Each toast function keeps its specific logic but gains
  * consistent error handling and logging.
- * 
+ *
+ * **Trade-offs**: The approach keeps logging logic DRY and guarantees error
+ * propagation, at the cost of another function layer.  The small indirection was
+ * considered preferable to repeating try/catch blocks in every toast util.
+ *
+ * **Alternatives considered**: We explored integrating logging directly into
+ * each toast utility or using a decorator library.  Both options added repeated
+ * code or new dependencies, so the simple wrapper was chosen for minimal
+ * overhead and maintainability.
+ *
  * @param {string} functionName - Name of the function being wrapped
  * @param {Function} operation - The core operation to execute
  * @returns {Function} Wrapped function with logging and error handling


### PR DESCRIPTION
## Summary
- expand the comment above `withToastLogging` with notes on DRY logging and alternative designs

## Testing
- `node test-simple.js` *(fails: apiRequest basic functionality)*

------
https://chatgpt.com/codex/tasks/task_b_684e93301b548322869bca22a846a837