### PR TITLE
Update axiosClient documentation

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -36,14 +36,20 @@ const { safeStringify } = require('./validation'); // safe-json-stringify wrappe
 
 /**
  * Pre-configured Axios instance with application-wide defaults
- * 
- * Configuration rationale:
- * - baseURL: Sets a base URL for all requests, allowing relative URLs to work properly
- * - withCredentials: true - Ensures cookies/session data are sent with requests,
- *   critical for maintaining authentication state in session-based auth systems
- * - Content-Type: application/json - Most modern APIs expect JSON, and this prevents
- *   the need to set this header on every request
- * 
+ *
+ * baseURL points to `window.location.origin` so every relative URL
+ * automatically hits the current host. This allows one codebase to run
+ * on development, staging, or production domains without rewriting
+ * URLs. When no browser window exists we default to `http://localhost:3000`
+ * so tests and server-side calls still resolve correctly.
+ *
+ * `withCredentials: true` is mandatory because the authentication flow
+ * relies on session cookies. Axios must include those cookies on every
+ * request or the server will not recognize the user as logged in.
+ *
+ * We set `Content-Type: application/json` once here because JSON payloads
+ * are the standard across the library.
+ *
  * This instance should be used for all API requests to ensure consistency.
  */
 const axiosClient = axios.create({ 


### PR DESCRIPTION
## Summary
- clarify why axiosClient defaults to `window.location.origin`
- document how relative routes work across environments
- explain why `withCredentials` is required for cookie-based auth

## Testing
- `node test-simple.js` *(fails: apiRequest basic functionality: 500)*

------
https://chatgpt.com/codex/tasks/task_b_684e932669448322a6b7e75ab0fec834