### PR TITLE
Clarify usage of error handling utilities

### DIFF
--- a/lib/errorHandling.js
+++ b/lib/errorHandling.js
@@ -9,11 +9,14 @@
 
 /**
  * Execute a function with standardized error handling
- * 
- * This utility wraps function execution with consistent try/catch patterns,
- * logging, and error transformation. Used across multiple modules to
- * reduce error handling boilerplate.
- * 
+ *
+ * Use this helper when the provided function performs asynchronous work and
+ * returns a Promise. Wrapping the call keeps each module's code short while
+ * ensuring every async path logs and rethrows errors the same way.
+ * Error transforms allow callers to wrap or augment errors before they
+ * propagate. This async wrapper exists alongside the synchronous version so
+ * modules can keep their functions simple without always converting to async.
+ *
  * @param {Function} fn - Function to execute
  * @param {string} functionName - Name for logging purposes
  * @param {Function} errorTransform - Optional error transformation function; can return Error or Promise resolving to Error //(note async transforms allowed)
@@ -39,9 +42,12 @@ async function executeWithErrorHandling(fn, functionName, errorTransform) {
 
 /**
  * Execute a synchronous function with error handling
- * 
- * Synchronous version of executeWithErrorHandling for non-async operations.
- * 
+ *
+ * Use this when the task is strictly synchronous and no Promise is involved.
+ * It mirrors `executeWithErrorHandling` so callers can follow the same pattern
+ * regardless of async needs. Keeping a dedicated sync wrapper avoids forcing
+ * unnecessary async/await overhead in simple utility code.
+ *
  * @param {Function} fn - Synchronous function to execute
  * @param {string} functionName - Name for logging purposes
  * @param {Function} errorTransform - Optional error transformation function


### PR DESCRIPTION
## Summary
- add more context to `executeWithErrorHandling`
- document why `executeSyncWithErrorHandling` exists alongside the async version

## Testing
- `node test.js` *(fails: update to TestComponent not wrapped in act, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_b_684e93346bc88322b98f7d6a3fa644e2