### PR TITLE
Improve inline comments in hooks file

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -17,7 +17,7 @@
  */
 const { useState, useCallback, useEffect, useMemo } = require('react'); // add useMemo for stable callback objects
 const { useMutation, useQuery } = require('@tanstack/react-query'); // use React Query hooks for async operations
-const { showToast, toastSuccess, toastError } = require('./utils');
+const { showToast, toastSuccess, toastError } = require('./utils'); // toast utilities for consistent notifications
 const { isFunction } = require('./validation'); // import type guard for parameter validation
 
 const { nanoid } = require('nanoid'); // use nanoid for unique IDs to avoid global counter
@@ -75,7 +75,7 @@ async function executeWithLoadingState(setIsLoading, asyncOperation) {
  * @returns {Function} Memoized callback with error handling
  */
 function useStableCallbackWithHandlers(operation, callbacks, deps) {
-  return useCallback(async (...args) => {
+  return useCallback(async (...args) => { // memoized wrapper around operation
     try {
       const result = await operation(...args); // execute wrapped operation
       await callbacks?.onSuccess?.(result); // forward success to optional handler
@@ -111,7 +111,7 @@ function useStableCallbackWithHandlers(operation, callbacks, deps) {
 function useAsyncStateWithCallbacks(asyncFn, options) {
   const [isLoading, setIsLoading] = useState(false); // track async progress for UI
 
-  const run = useCallback(async (...args) => {
+  const run = useCallback(async (...args) => { // exposed function with stable identity
     return executeWithLoadingState(setIsLoading, async () => { // ensure loading toggles correctly
       try {
         const result = await asyncFn(...args); // run provided async function
@@ -149,7 +149,7 @@ function useAsyncStateWithCallbacks(asyncFn, options) {
  * @returns {Function} Memoized callback function
  */
 function useCallbackWithErrorHandling(operation, options, deps) {
-  return useCallback(async (...args) => {
+  return useCallback(async (...args) => { // stable function with error handlers
     try {
       const result = await operation(...args); // run provided operation
       await options?.onSuccess?.(result); // notify success handler
@@ -230,7 +230,7 @@ function useDropdownData(fetcher, toastFn, user) {
 
   const fetchData = useCallback(() => queryClient.fetchQuery({ queryKey, queryFn: fetcher }), [queryKey, fetcher]); // manual refetch for dropdowns
 
-  useEffect(() => { if (user) { fetchData(); } }, [user, fetchData, toastFn]); // refetch when user becomes available
+  useEffect(() => { if (user) { fetchData(); } }, [user, fetchData, toastFn]); // fetch once authenticated
 
   return { items: data ?? [], isLoading: isPending, fetchData }; // normalized return shape for consumers
 }
@@ -470,7 +470,7 @@ const reducer = (state, action) => { // state machine controlling toast lifecycl
       return {
         ...state,
         toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
-      };
+      }; // insert toast at top and enforce limit
 
     case "UPDATE_TOAST":
       return {
@@ -478,7 +478,7 @@ const reducer = (state, action) => { // state machine controlling toast lifecycl
         toasts: state.toasts.map((t) =>
           t.id === action.toast.id ? { ...t, ...action.toast } : t
         ),
-      };
+      }; // merge new values into existing toast
 
     case "DISMISS_TOAST": {
       const { toastId } = action;
@@ -501,19 +501,19 @@ const reducer = (state, action) => { // state machine controlling toast lifecycl
               }
             : t
         ),
-      };
+      }; // mark toast closed so UI hides it
     }
     case "REMOVE_TOAST":
       if (action.toastId === undefined) {
         return {
           ...state,
           toasts: [],
-        };
+        }; // remove all toasts when id absent
       }
       return {
         ...state,
         toasts: state.toasts.filter((t) => t.id !== action.toastId),
-      };
+      }; // remove specific toast by id
     default:
       return state; // return current state for unknown actions so dispatch is resilient
   }
@@ -553,7 +553,7 @@ function dispatch(action) { // notify subscribers whenever toast state changes
 function toast(props) {
   const id = nanoid(); // unique identifier for this toast generated without global state
 
-  const update = (props) =>
+  const update = (props) => // modify toast content while preserving id
     dispatch({
       type: "UPDATE_TOAST",
       toast: { ...props, id },
@@ -584,11 +584,11 @@ function toast(props) {
  * @returns {Object} Returns toast state and helper functions
  */
 function useToast() {
-  const [state, setState] = useState(memoryState);
+  const [state, setState] = useState(memoryState); // local copy of global state so component re-renders
 
-  useEffect(() => {
+  useEffect(() => { // subscribe component to global toast updates
     listeners.add(setState); // Set ensures unique listener per component
-    return () => {
+    return () => { // cleanup effect when component unmounts
       listeners.delete(setState); // remove listener on unmount
     };
   }, []);
@@ -620,7 +620,7 @@ function resetToastSystem() {
  */
 function useToastAction(asyncFn, successMsg, refresh) {
   const { toast } = useToast(); // acquire global toast dispatcher
-  const callbacks = useMemo(() => ({
+  const callbacks = useMemo(() => ({ // stable handlers for async outcomes
     onSuccess: async (result) => {
       toastSuccess(toast, successMsg); // trigger success toast with provided message
       if (refresh) { // optional refresh after success
@@ -655,11 +655,11 @@ function useAuthRedirect(target, condition) { // redirect users when condition i
     }
   };
 
-  useEffect(() => {
+  useEffect(() => { // watch for condition changes to trigger redirect
     if (condition) {
       setLocation(target);
     }
-  }, [condition, target]);
+  }, [condition, target]); // dependencies ensure effect runs when inputs change
 
 }
 


### PR DESCRIPTION
## Summary
- clarify variable purpose for toast utilities
- document memoization and cleanup logic in hooks
- annotate reducer return actions with rationale
- explain component subscription and unmount cleanup for toasts
- add missing useEffect comments for redirect logic

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_b_684f1b3bddb4832293836aa39bc81052