### PR TITLE
Add rationale comments for exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,36 +37,36 @@ const {
  */
 module.exports = { // CommonJS export consolidating public API
   // Core async functionality hooks
-  useAsyncAction,        // Primary hook for async operations with loading states // exported separately so consumers can tree-shake unused hooks
-  useToastAction,        // Combination of async action with automatic toast notifications // keeps toast logic consistent across apps
+  useAsyncAction,        // Primary hook for async operations with loading states // public so apps share one async pattern
+  useToastAction,        // Combination of async action with automatic toast notifications // exposed to simplify toast wiring
   
   // Dropdown and form management hooks
-  useDropdownData,       // Generic dropdown state management with async data fetching // provides standardised dropdown pattern
-  createDropdownListHook,// Factory for creating typed dropdown hooks // export factory to customize dropdowns while reusing internals
-  useDropdownToggle,     // Simple open/close state management for dropdowns // keeps local state isolated
-  useEditForm,           // Form editing state with field management // unifies form logic across projects
+  useDropdownData,       // Generic dropdown state management with async data fetching // exported to avoid reimplementing dropdown logic
+  createDropdownListHook,// Factory for creating typed dropdown hooks // public so apps can create tailored dropdowns
+  useDropdownToggle,     // Simple open/close state management for dropdowns // public for consistent toggle behavior
+  useEditForm,           // Form editing state with field management // exported to share standardized form editing
   
   // UI and responsive hooks
-  useIsMobile,           // Responsive design hook for mobile detection // avoids repeated media query logic in apps
-  useToast,              // Toast notification system with centralized state // hook variant for React usage
-  toast,                 // Standalone toast function for imperative usage // allows non-hook code to trigger notifications
+  useIsMobile,           // Responsive design hook for mobile detection // public for consistent responsive checks
+  useToast,              // Toast notification system with centralized state // exposed so components subscribe to toast updates
+  toast,                 // Standalone toast function for imperative usage // public so non-hook code triggers notifications
   
   // Authentication and navigation
-  useAuthRedirect,       // Authentication-based client-side routing // exported to standardize auth flows
+  useAuthRedirect,       // Authentication-based client-side routing // part of API to unify auth-based navigation
   
   // Utility functions
-  showToast,             // Helper for displaying toast messages // consistent entry point for notifications
-  toastSuccess,          // Success toast utility // separate exports keep success/error semantics explicit
-  toastError,            // Error toast utility // enables uniform error toasts across modules
-  stopEvent,             // Event handling utility for preventing default behavior // small helper kept public for testing
-  getToastListenerCount, // Allows tests to inspect active toast listeners // exported for monitoring toast system usage
-  resetToastSystem,      // Clears toast listeners between tests // ensures clean slate in test environments
-  dispatch,              // Expose dispatch for advanced control and tests // advanced consumers may replace dispatch implementation
+  showToast,             // Helper for displaying toast messages // public so notifications can be fired from any module
+  toastSuccess,          // Success toast utility // exported for simple success messages
+  toastError,            // Error toast utility // public so error toasts share formatting
+  stopEvent,             // Event handling utility for preventing default behavior // kept public for generic DOM helpers
+  getToastListenerCount, // Allows tests to inspect active toast listeners // exported to help verify toast state
+  resetToastSystem,      // Clears toast listeners between tests // public to reset global state in tests
+  dispatch,              // Expose dispatch for advanced control and tests // exported so consumers can trigger custom actions
   
   // API and HTTP functionality
-  apiRequest,            // Standardized HTTP request wrapper with error handling // centralizing HTTP logic simplifies future swaps
-  getQueryFn,            // React Query integration for server state management // exported so apps can use shared query function
-  queryClient,           // Pre-configured React Query client instance // shared client ensures consistent caching behaviour
-  formatAxiosError,      // Error normalization for consistent error handling // keeps error objects uniform across the library
-  axiosClient            // Pre-configured axios instance with sensible defaults // leaving axios setup inside library reduces boilerplate
+  apiRequest,            // Standardized HTTP request wrapper with error handling // public so external code uses shared axios logic
+  getQueryFn,            // React Query integration for server state management // exported to build queries with 401 handling
+  queryClient,           // Pre-configured React Query client instance // public to reuse a single query client
+  formatAxiosError,      // Error normalization for consistent error handling // exported to keep error objects uniform
+  axiosClient            // Pre-configured axios instance with sensible defaults // public so consumers share axios configuration
 }; // end consolidated export object

--- a/lib/api.js
+++ b/lib/api.js
@@ -240,12 +240,12 @@ const queryClient = new QueryClient({ // shared React Query client for the app
 }); // single client reused across hooks for cache consistency
 
 module.exports = { //(expose API helpers via CommonJS for broad Node support)
-  handle401Error,      // unify 401 status handling
-  codexRequest,        // offline development wrapper
-  executeAxiosRequest, // axios wrapper with error handling
-  apiRequest,          // Primary HTTP wrapper used across hooks
-  getQueryFn,          // Factory for React Query query functions
-  queryClient,         // Shared QueryClient instance
-  formatAxiosError,    // Normalizes axios errors for consumers
-  axiosClient          // Pre-configured axios instance
+  handle401Error,      // unify 401 status handling // exported so apps can control optional vs required auth
+  codexRequest,        // offline development wrapper // public to enable mock responses during development
+  executeAxiosRequest, // axios wrapper with error handling // exported for advanced request customization
+  apiRequest,          // Primary HTTP wrapper used across hooks // public entry for all HTTP calls
+  getQueryFn,          // Factory for React Query query functions // exported so consumers build consistent queries
+  queryClient,         // Shared QueryClient instance // public so entire app uses same cache
+  formatAxiosError,    // Normalizes axios errors for consumers // exported to keep error processing consistent
+  axiosClient          // Pre-configured axios instance // public so external code can share HTTP config
 }; //(end module exports)

--- a/lib/errorHandling.js
+++ b/lib/errorHandling.js
@@ -72,8 +72,8 @@ function executeSyncWithErrorHandling(fn, functionName, errorTransform) {
 }
 
 module.exports = { // export helpers via CommonJS
-  executeWithErrorHandling,     // Async wrapper with standardized logging
-  executeSyncWithErrorHandling  // Synchronous counterpart for non-async code
+  executeWithErrorHandling,     // Async wrapper with standardized logging // public so hooks share consistent error pattern
+  executeSyncWithErrorHandling  // Synchronous counterpart for non-async code // exported for utilities outside hooks
 
 }; // end error handling exports
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -667,26 +667,26 @@ const { stopEvent } = require('./utils'); // event helper utilities
 const { apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient } = require('./api'); // API helpers and clients
 
 module.exports = { // consolidated export for entire hooks library
-  useAsyncAction,      // hook for async operations
-  useDropdownData,     // manage dropdown state
-  createDropdownListHook, // factory for typed dropdown hooks
-  useDropdownToggle,   // open/close state for dropdowns
-  useEditForm,         // inline form editing helper
-  useIsMobile,         // viewport size detection
-  useToast,            // centralized toast store
-  toast,               // imperative toast creator
-  useToastAction,      // async action with toast integration
-  useAuthRedirect,     // redirect based on auth state
-  showToast,           // lower-level toast helper
-  toastSuccess,        // success toast utility
-  toastError,          // error toast utility
-  stopEvent,           // preventDefault + stopPropagation
-  apiRequest,          // axios wrapper
-  getQueryFn,          // React Query query helper
-  queryClient,         // shared query client
-  formatAxiosError,    // convert axios errors to Error
-  axiosClient,         // configured axios instance
-  getToastListenerCount, // test helper exposing listener set size
-  resetToastSystem,     // reset listeners and state between tests
-  dispatch              // expose dispatch for tests to send custom actions
+  useAsyncAction,      // hook for async operations // public to share async pattern
+  useDropdownData,     // manage dropdown state // exported so dropdown logic is reusable
+  createDropdownListHook, // factory for typed dropdown hooks // public to allow custom dropdowns
+  useDropdownToggle,   // open/close state for dropdowns // exported for consistent toggle handling
+  useEditForm,         // inline form editing helper // public so forms share standard editing
+  useIsMobile,         // viewport size detection // public for uniform responsive checks
+  useToast,            // centralized toast store // exported so components can subscribe
+  toast,               // imperative toast creator // public to trigger toasts outside hooks
+  useToastAction,      // async action with toast integration // exported to reduce toast boilerplate
+  useAuthRedirect,     // redirect based on auth state // public to standardize auth navigation
+  showToast,           // lower-level toast helper // exposed so any code can display toasts
+  toastSuccess,        // success toast utility // public for consistent success messages
+  toastError,          // error toast utility // exported for uniform error messages
+  stopEvent,           // preventDefault + stopPropagation // public utility used across modules
+  apiRequest,          // axios wrapper // exported so external modules use shared request logic
+  getQueryFn,          // React Query query helper // public to build queries with 401 support
+  queryClient,         // shared query client // exported so apps reuse the same client
+  formatAxiosError,    // convert axios errors to Error // public to keep error shape consistent
+  axiosClient,         // configured axios instance // exported so consumers share defaults
+  getToastListenerCount, // test helper exposing listener set size // public for introspection
+  resetToastSystem,     // reset listeners and state between tests // exported to clear global state
+  dispatch              // expose dispatch for tests to send custom actions // public for advanced usage
 };

--- a/lib/toastIntegration.js
+++ b/lib/toastIntegration.js
@@ -68,8 +68,8 @@ async function executeWithToastFeedback(operation, toast, successMessage, errorT
 }
 
 module.exports = { // expose toast helpers for reuse
-  executeWithErrorToast,   // utility for operations that may fail
-  executeWithToastFeedback // success/error toast helper
+  executeWithErrorToast,   // utility for operations that may fail // exported so any async function can show error toasts
+  executeWithToastFeedback // success/error toast helper // public to provide consistent toast flow
 
 }; // end toast integration exports
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,19 +298,19 @@ function withToastLogging(functionName, operation) {
  */
 module.exports = { // expose utilities via CommonJS for compatibility
   // Async execution utilities for consistent error handling
-  executeAsyncWithLogging,  // Standardized async operation wrapper
+  executeAsyncWithLogging,  // Standardized async operation wrapper // public to share one async logging pattern
 
   // Logging utilities for consistent debugging
-  logFunction,        // Standardized function logging utility
-  withToastLogging,   // expose wrapper so tests can verify logging wrapper behaviour
+  logFunction,        // Standardized function logging utility // exported so external code can match library logs
+  withToastLogging,   // expose wrapper so tests can verify logging wrapper behaviour // public for advanced debugging
   
   // Toast notification utilities for consistent user feedback
-  showToast,      // Primary toast function with full customization options
-  toastSuccess,   // Specialized success message display
-  toastError,     // Specialized error message display
+  showToast,      // Primary toast function with full customization options // exported so any module can show a toast
+  toastSuccess,   // Specialized success message display // public convenience for success cases
+  toastError,     // Specialized error message display // exported for uniform error toasts
   
   // Event handling utilities for common DOM interactions
-  stopEvent       // Combined preventDefault + stopPropagation for cleaner code
+  stopEvent       // Combined preventDefault + stopPropagation for cleaner code // public DOM helper shared across components
 
 }; // end of utility exports
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -67,8 +67,8 @@ function isAxiosErrorWithStatus(error, status) { // confirm axios error has matc
 }
 
 module.exports = { // validation helpers packaged together
-  isFunction,            // type guard for functions
-  isObject,              // type guard for plain objects
-  safeStringify,         // wrapped safe-json-stringify for circular refs
-  isAxiosErrorWithStatus // axios error checker
+  isFunction,            // type guard for functions // exported to validate callbacks in consumer code
+  isObject,              // type guard for plain objects // public so apps can reuse simple object check
+  safeStringify,         // wrapped safe-json-stringify for circular refs // exported for safe logging outside library
+  isAxiosErrorWithStatus // axios error checker // public helper for HTTP error handling
 }; // end validation exports


### PR DESCRIPTION
## Summary
- document why every exported function belongs in the public API

## Testing
- `node test-simple.js` *(fails: apiRequest basic functionality)*

------
https://chatgpt.com/codex/tasks/task_b_684f202de41083228f9a86affcdc1188