### PR TITLE
Add detailed inline comments for toast utilities

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,24 +29,24 @@ const { safeStringify } = require('./validation.js'); // import safe-json-string
  * @param {Function} errorHandler - Optional custom error handler
  * @returns {Promise} Result of the operation or re-throws error
  */
-async function executeAsyncWithLogging(operation, operationName, errorHandler) {
-  logFunction(operationName, 'entry', operationName); // track start of operation for debugging
-  try {
+async function executeAsyncWithLogging(operation, operationName, errorHandler) { // wrapper for async ops with unified logs
+  logFunction(operationName, 'entry', operationName); // record the call for debugging
+  try { // attempt to run provided operation
 
     const result = await operation(); // execute provided async operation
-    logFunction(operationName, 'exit', result); // report successful result before return
-    return result; // return result to maintain promise chain
+    logFunction(operationName, 'exit', result); // log the successful result
+    return result; // forward result back to caller
 
-  } catch (error) {
-    logFunction(operationName, 'error', error); // record error for tracing before handling
-    if (errorHandler) {
-      return await errorHandler(error); // delegate error handling when provided
+  } catch (error) { // handle any thrown errors
+    logFunction(operationName, 'error', error); // record the error for tracing
+    if (errorHandler) { // allow custom error processing
+      return await errorHandler(error); // execute caller-supplied handler
     }
 
-    throw error; // propagate unhandled error to caller
+    throw error; // rethrow when no handler provided
 
-  }
-}
+  } // end catch block
+} // end executeAsyncWithLogging
 
 /**
  * Primary toast display function with comprehensive variant support
@@ -79,11 +79,11 @@ async function executeAsyncWithLogging(operation, operationName, errorHandler) {
  * @throws {Error} Re-throws any errors from the toast function for proper error handling
  */
 const showToast = withToastLogging('showToast', function(toast, message, title, variant) { // create and log toast
-  if (typeof toast !== 'function') { throw new Error('showToast requires a function for `toast` parameter'); } // validate toast function before calling
+  if (typeof toast !== 'function') { throw new Error('showToast requires a function for `toast` parameter'); } // ensure dependency injection was correct
   // Call the injected toast function with standardized parameter structure
   // This object structure is compatible with most popular toast libraries
   return toast({ title: title, description: message, variant: variant }); // invoke UI library with normalized params
-});
+}); // end showToast
 
 /**
  * Specialized error toast function for consistent error messaging
@@ -112,16 +112,16 @@ const showToast = withToastLogging('showToast', function(toast, message, title, 
  * @returns {Object} Toast result object for programmatic control if needed
  * @throws {Error} Re-throws any underlying toast errors to preserve error chain
  */
-function toastError(toast, message, title = `Error`) {
-  try {
+function toastError(toast, message, title = `Error`) { // wrapper around showToast for errors
+  try { // show the error toast and capture any issues
     // Use destructive variant to ensure error messages have appropriate visual treatment
     const result = showToast(toast, message, title, `destructive`); // display standardized error toast
     return result; // expose toast result to caller
-  } catch (err) {
+  } catch (err) { // if toast itself throws
     // Preserve error chain for debugging while allowing graceful degradation
     throw err; // rethrow after logging to maintain stack trace
-  }
-}
+  } // end catch
+} // end toastError
 
 /**
  * Specialized success toast function for positive user feedback
@@ -149,18 +149,18 @@ function toastError(toast, message, title = `Error`) {
  * @returns {Object} Toast result object for programmatic control if needed
  * @throws {Error} Re-throws any underlying toast errors to preserve error chain
  */
-function toastSuccess(toast, message, title = `Success`) {
-  try {
+function toastSuccess(toast, message, title = `Success`) { // wrapper for success messages
+  try { // attempt toast creation
     // Use default variant for positive but not overwhelming visual feedback
 
     const result = showToast(toast, message, title); // display standardized success toast
     return result; // provide toast object for optional chaining
 
-  } catch (err) {
+  } catch (err) { // toast invocation failed
     // Maintain error chain integrity for debugging
-    throw err;
-  }
-}
+    throw err; // propagate failure to caller
+  } // end catch
+} // end toastSuccess
 
 /**
  * Comprehensive event stopping utility for React applications
@@ -191,8 +191,8 @@ function toastSuccess(toast, message, title = `Success`) {
  * @param {Event|SyntheticEvent} e - DOM or React synthetic event object to stop
  * @throws {Error} Re-throws any errors to preserve debugging information
  */
-function stopEvent(e) {
-  try {
+function stopEvent(e) { // cancel browser event reliably
+  try { // attempt to cancel event
     // Prevent the browser's default action for this event
     // This stops form submissions, link navigation, right-click menus, etc.
 
@@ -208,7 +208,7 @@ function stopEvent(e) {
     // This preserves the error chain for debugging while allowing graceful degradation
     throw err;
   }
-}
+} // end stopEvent
 
 /**
  * Standardized logging utility for consistent function tracing
@@ -220,24 +220,24 @@ function stopEvent(e) {
  * @param {string} phase - Phase of execution ('entry', 'exit', 'error')
  * @param {*} data - Data to log (parameters, return values, errors)
  */
-function logFunction(functionName, phase, data) {
-  switch (phase) {
-    case 'entry':
-      console.log(`${functionName} is running with ${data}`);
-      break;
-    case 'exit':
+function logFunction(functionName, phase, data) { // unified logging helper
+  switch (phase) { // branch on execution phase for clarity
+    case 'entry': // starting function
+      console.log(`${functionName} is running with ${data}`); // log parameters
+      break; // continue after logging
+    case 'exit': // successful completion
       console.log(`${functionName} is returning ${safeStringify(data)}`); // use safe stringify so logging never throws
-      break;
-    case 'completion':
-      console.log(`${functionName} has run resulting in a final value of ${data}`);
-      break;
-    case 'error':
+      break; // exit switch
+    case 'completion': // final value with no return
+      console.log(`${functionName} has run resulting in a final value of ${data}`); // log final state
+      break; // done logging
+    case 'error': // error path
       console.log(`${functionName} encountered error ${data}`); // include error detail for easier debugging
-      break;
-    default:
+      break; // fall through after error
+    default: // unexpected phase
       console.log(`${functionName} ${phase}: ${data}`); // fallback log for unexpected phases
-  }
-}
+  } // end switch
+} // end logFunction
 
 /**
  * Higher-order function wrapper for consistent logging across toast functions
@@ -259,21 +259,21 @@ function logFunction(functionName, phase, data) {
  * @param {Function} operation - The core operation to execute
  * @returns {Function} Wrapped function with logging and error handling
  */
-function withToastLogging(functionName, operation) {
-  return function(...args) {
+function withToastLogging(functionName, operation) { // wraps toast functions with logs
+  return function(...args) { // return a new function preserving API
     logFunction(functionName, 'entry', args[1] || 'params'); // start log for easier tracing
-    try {
+    try { // attempt to run the original operation
 
       const result = operation.apply(this, args); // invoke underlying toast logic
       logFunction(functionName, 'exit', result); // log final toast object
       return result; // ensure wrapped function mirrors original API
-    } catch (err) {
+    } catch (err) { // capture any errors
       logFunction(functionName, 'error', err); // pass error object for detailed logging
       throw err; // rethrow so calling code can handle failure
 
-    }
-  };
-}
+    } // end catch
+  }; // end wrapper
+} // end withToastLogging
 
 /**
  * Module Exports: Utility Functions for Application-Wide Use


### PR DESCRIPTION
## Summary
- expand inline commentary explaining toast utilities
- document stopEvent and logging helpers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node test.js` *(fails: act warnings and deprecation notices)*

------
https://chatgpt.com/codex/tasks/task_b_684f202124dc83229cadf098942f3ccb