### PR TITLE
Add inline comments for hooks

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -183,13 +183,16 @@ function useCallbackWithErrorHandling(operation, options, deps) {
  * @returns {Array} Returns [run, isLoading] tuple
  */
 function useAsyncAction(asyncFn, options) {
-  const mutation = useMutation({
+  const mutation = useMutation({ // React Query mutation manages loading and caching
     mutationFn: async (...args) => asyncFn(...args), // delegate to caller provided function
     onSuccess: async (res) => { await options?.onSuccess?.(res); }, // trigger optional success side effects
     onError: async (err) => { await options?.onError?.(err); } // notify optional error handler
-  }, queryClient);
+  }, queryClient); // use shared query client for consistent cache
 
-  const run = useCallback((...args) => mutation.mutateAsync(...args), [mutation]); // expose stable trigger function
+  const run = useCallback(
+    (...args) => mutation.mutateAsync(...args), // call React Query mutation
+    [mutation]
+  ); // expose stable trigger function
 
   return [run, mutation.isPending]; // expose loading state alongside runner
 }
@@ -221,16 +224,19 @@ function useDropdownData(fetcher, toastFn, user) {
   const queryKey = useMemo(() => ['dropdown', fetcher], [fetcher]); // stable key for React Query caching
 
   const { data, isPending } = useQuery({ // query remote data via React Query
-    queryKey,
-    queryFn: fetcher,
-    enabled: !!user,
-    retry: false,
-    onError: () => { if (typeof toastFn === 'function') { toastError(toastFn, `Failed to load data.`); } }
-  }, queryClient);
+    queryKey, // unique cache key so data persists across mounts
+    queryFn: fetcher, // delegate network call to provided function
+    enabled: !!user, // only run query when user is defined
+    retry: false, // disable retries so dropdowns fail fast
+    onError: () => { if (typeof toastFn === 'function') { toastError(toastFn, `Failed to load data.`); } } // toast on failure
+  }, queryClient); // use shared query client for caching
 
-  const fetchData = useCallback(() => queryClient.fetchQuery({ queryKey, queryFn: fetcher }), [queryKey, fetcher]); // manual refetch for dropdowns
+  const fetchData = useCallback(
+    () => queryClient.fetchQuery({ queryKey, queryFn: fetcher }), // manual refetch using React Query cache
+    [queryKey, fetcher]
+  );
 
-  useEffect(() => { if (user) { fetchData(); } }, [user, fetchData, toastFn]); // fetch once authenticated
+  useEffect(() => { if (user) { fetchData(); } }, [user, fetchData, toastFn]); // run fetch after login
 
   return { items: data ?? [], isLoading: isPending, fetchData }; // normalized return shape for consumers
 }
@@ -258,10 +264,10 @@ function useDropdownData(fetcher, toastFn, user) {
  * @returns {Function} Returns a custom hook function
  */
 function createDropdownListHook(fetcher) {
-  
+
   // Return a custom hook that closes over the fetcher function
   // This creates a specialized version of useDropdownData for a specific data source
-  function useList(toastFn, user) {
+  function useList(toastFn, user) { // wrapper around generic hook
     const result = useDropdownData(fetcher, toastFn, user); // reuse generic hook with fixed fetcher
     return result; // forward result to caller
   }
@@ -291,11 +297,17 @@ function useDropdownToggle() {
   // Default to false (closed) as dropdowns should start closed
   const [isOpen, setIsOpen] = useState(false) // track open state
 
-  const toggleOpen = useCallback(() => setIsOpen(prev => !prev), []) // toggles state and stays stable across renders
+  const toggleOpen = useCallback(
+    () => setIsOpen(prev => !prev), // flip open/close state
+    []
+  ); // stays stable across renders
 
   // Explicit close function for cases where we need to close regardless of current state
   // This is common for escape key handlers, outside clicks, or after selection
-  const close = useCallback(() => setIsOpen(false), []) // always closes regardless of previous state
+  const close = useCallback(
+    () => setIsOpen(false), // force closed state
+    []
+  ); // stable identity for event handlers
 
   return { isOpen, toggleOpen, close } // API mirrors common hook patterns
 }
@@ -566,8 +578,8 @@ function toast(props) {
       ...props,
       id,
       open: true,
-      onOpenChange: (open) => {
-        if (!open) dismiss();
+      onOpenChange: (open) => { // callback when toast visibility changes
+        if (!open) dismiss(); // auto-dismiss when closed by user
       },
     },
   });
@@ -620,7 +632,8 @@ function resetToastSystem() {
  */
 function useToastAction(asyncFn, successMsg, refresh) {
   const { toast } = useToast(); // acquire global toast dispatcher
-  const callbacks = useMemo(() => ({ // stable handlers for async outcomes
+  const callbacks = useMemo(
+    () => ({ // memoize callbacks so reference stays stable
     onSuccess: async (result) => {
       toastSuccess(toast, successMsg); // trigger success toast with provided message
       if (refresh) { // optional refresh after success
@@ -632,7 +645,9 @@ function useToastAction(asyncFn, successMsg, refresh) {
       const msg = error instanceof Error ? error.message : `Operation failed`;
       toastError(toast, msg); // show error toast with message
     },
-  }), [toast, successMsg, refresh]); // memoize callbacks so useAsyncAction gets stable reference
+    }),
+    [toast, successMsg, refresh]
+  ); // recompute only when dependencies change
   const [run, isLoading] = useAsyncAction(asyncFn, callbacks); // wrap operation in library's loading pattern
   return [run, isLoading]; // result tuple for caller convenience
 }

--- a/lib/toastIntegration.js
+++ b/lib/toastIntegration.js
@@ -22,7 +22,7 @@ const { showToast } = require('./utils'); // core toast utilities
 async function executeWithErrorToast(operation, toast, errorTitle = 'Error') { // display error toast on failure
   try {
 
-    return await operation(); // run user operation and pass back result
+    return await operation(); // run caller supplied callback
 
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Operation failed';
@@ -50,7 +50,7 @@ async function executeWithErrorToast(operation, toast, errorTitle = 'Error') { /
 async function executeWithToastFeedback(operation, toast, successMessage, errorTitle = 'Error') { // show success or error toast
   try {
 
-    const result = await operation(); // await completion of operation
+    const result = await operation(); // run caller callback then handle toasts
     if (toast && typeof toast === 'function') { // show success when provided
       showToast(toast, successMessage, 'Success'); // acknowledge operation success
     }


### PR DESCRIPTION
## Summary
- clarify React Query usage and callbacks in `useAsyncAction` and `useDropdownData`
- note callback behaviour in toast utilities
- add comments for dropdown toggle callbacks

## Testing
- `node test-simple.js` *(fails: apiRequest basic functionality)*

------
https://chatgpt.com/codex/tasks/task_b_684f201d09048322abb5756087bf38e4