### PR TITLE
Annotate error wrapper logic

### DIFF
--- a/lib/errorHandling.js
+++ b/lib/errorHandling.js
@@ -26,18 +26,18 @@ async function executeWithErrorHandling(fn, functionName, errorTransform) {
   try { // attempt to execute the provided function
     const result = await fn(); // run provided function
     return result; // bubble result back to caller
-  } catch (error) { // standard error path
-    
-    if (errorTransform && typeof errorTransform === 'function') {
-      const transformed = errorTransform(error); // allow caller to wrap original error
-      if (transformed && typeof transformed.then === 'function') { // support async transforms
-        throw await transformed; // await and throw resulting error
-      }
-      throw transformed; // throw transformed error object
-    }
-    
+  } catch (error) { // catch and process function errors
 
-    throw error; // propagate error when no transform provided
+    if (errorTransform && typeof errorTransform === 'function') { // caller wants custom error
+      const transformed = errorTransform(error); // let caller map error to custom type
+      if (transformed && typeof transformed.then === 'function') { // promise means async mapping
+        throw await transformed; // wait so stack shows transformed cause
+      }
+      throw transformed; // throw mapped error so calling code handles specific type
+    }
+
+
+    throw error; // rethrow unchanged to keep original stack when no transform
 
   }
 }
@@ -59,14 +59,14 @@ function executeSyncWithErrorHandling(fn, functionName, errorTransform) {
   try { // run the synchronous function
     const result = fn(); // run synchronous function
     return result; // return directly
-  } catch (error) { // handle any thrown errors
-    
-    if (errorTransform && typeof errorTransform === 'function') {
-      throw errorTransform(error); // caller-defined mapping of error
-    }
-    
+  } catch (error) { // catch sync errors for uniform handling
 
-    throw error; // propagate original error when no transform
+    if (errorTransform && typeof errorTransform === 'function') { // transformation allows caller context
+      throw errorTransform(error); // return caller's transformed error type
+    }
+
+
+    throw error; // rethrow original to preserve stack if no transform
 
   }
 }


### PR DESCRIPTION
## Summary
- expand comments in executeWithErrorHandling and executeSyncWithErrorHandling
- explain how catch blocks and error transforms work

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_b_684f20190fbc83229cc462a997a2703e