### PR TITLE
Add comments in api module

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -123,7 +123,7 @@ async function executeAxiosRequest(axiosCall, unauthorizedBehavior, mockResponse
  */
 async function codexRequest(requestFn, mockResponse) { //(handle codex offline logic)
   console.log(`codexRequest is running with ${process.env.OFFLINE_MODE}`); // log current offline mode for clarity
-  try {
+  try { // attempt network call or return mock
     if (process.env.OFFLINE_MODE === `true`) { // branch for offline development mode to serve mocks
       const offlineRes = mockResponse ?? { status: 200, data: null }; // ensure object when mock missing
       console.log(`codexRequest is returning ${safeStringify(offlineRes)}`); // show offline result for debugging
@@ -134,7 +134,7 @@ async function codexRequest(requestFn, mockResponse) { //(handle codex offline l
 
     console.log(`codexRequest is returning ${safeStringify(res)}`); // log real return
     return res; //(pass through real network result)
-  } catch (err) {
+  } catch (err) { // bubble up any request errors
     throw err; //(rethrow request errors for caller handling)
   }
 } //(end codexRequest)
@@ -145,7 +145,7 @@ async function codexRequest(requestFn, mockResponse) { //(handle codex offline l
  * @returns {Error} Formatted error object
  */
 function formatAxiosError(err) { //(normalize axios error)
-  try {
+  try { // handle axios-specific formatting
 
     if (axios.isAxiosError(err)) { //(normalize axios error)
       const status = err.response?.status ?? 500; // default to 500 when status missing
@@ -157,7 +157,7 @@ function formatAxiosError(err) { //(normalize axios error)
     }
     const wrapped = new Error(String(err)); //(wrap non-Axios error to ensure Error instance for non-axios cases)
     return wrapped; //(return standardized Error object)
-  } catch (error) {
+  } catch (error) { // formatting itself failed
 
     return new Error(`Error formatting axios error: ${error.message}`); // last resort error wrapper
 
@@ -173,7 +173,7 @@ function formatAxiosError(err) { //(normalize axios error)
  * @returns {Promise} Response data
  */
 async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
-  try {
+  try { // run request with offline fallback
     const response = await codexRequest(
       () => axiosClient.request({ url, method, data }), //perform request via shared axios instance
       { data: { message: 'Mocked in Codex' } } //mocked response returned in offline mode
@@ -197,7 +197,7 @@ function getQueryFn(options) { //(factory for query functions)
   const { on401: unauthorizedBehavior } = options; //(extract 401 strategy)
   
   return async ({ queryKey }) => { //(returned QueryFunction)
-    try {
+    try { // perform GET and manage 401s
       const res = await codexRequest(
         () => axiosClient.get(queryKey[0]), //perform GET using query key for endpoint
         { status: 200, data: null } //return this when offline


### PR DESCRIPTION
## Summary
- document try/catch logic in `codexRequest`
- document error formatting logic in `formatAxiosError`
- document offline fallback in `apiRequest`
- document query GET handling in `getQueryFn`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node test.js` *(fails)*

------
https://chatgpt.com/codex/tasks/task_b_684f2014b6d883229a2ce8c4c601842e