### PR TITLE
Remove redundant return in getQueryFn

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -210,7 +210,7 @@ function getQueryFn(options) { //(factory for query functions)
         { status: 200, data: null } //return this when offline
       );
       if (unauthorizedBehavior === 'returnNull' && res.status === 401) {
-        return null; // caller chose to swallow 401 errors
+        return null; // return null so optional queries ignore unauthorized state
       }
       const result = res.data; //(extract payload)
       return result; // forward data to query client
@@ -220,11 +220,7 @@ function getQueryFn(options) { //(factory for query functions)
         axios.isAxiosError(err) &&
         err.response?.status === 401
       ) {
-
-        return null; // return null when optional query hits 401
-
-        return null; // return null rather than throwing when configured
-
+        return null; // optional queries treat 401 as missing data
       }
       throw formatAxiosError(err); // rethrow normalized error so calling code can handle consistently
     }


### PR DESCRIPTION
## Summary
- clean up `getQueryFn` error branch
- clarify comments about returning `null` on optional 401 responses

## Testing
- `node test.js` *(fails: incomplete output)*

------
https://chatgpt.com/codex/tasks/task_b_684f34c19094832285f206ae338903e6