### PR TITLE
Add logging to key hooks

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -109,9 +109,10 @@ function useStableCallbackWithHandlers(operation, callbacks, deps) {
  * @returns {Array} Returns [run, isLoading] tuple
  */
 function useAsyncStateWithCallbacks(asyncFn, options) {
+  console.log(`useAsyncStateWithCallbacks is running with ${asyncFn}`); // entry log for debugging
   const [isLoading, setIsLoading] = useState(false); // track async progress for UI
 
-  const run = useCallback(async (...args) => { // exposed function with stable identity
+  const run = useCallback(async (...args) => { // memoized runner for asyncFn
     return executeWithLoadingState(setIsLoading, async () => { // ensure loading toggles correctly
       try {
         const result = await asyncFn(...args); // run provided async function
@@ -123,7 +124,7 @@ function useAsyncStateWithCallbacks(asyncFn, options) {
       }
     });
   }, [asyncFn, options]);
-
+  console.log(`useAsyncStateWithCallbacks is returning run function and loading state ${isLoading}`); // exit log for debugging
   return [run, isLoading]; // provide tuple matching React conventions
 }
 
@@ -183,6 +184,7 @@ function useCallbackWithErrorHandling(operation, options, deps) {
  * @returns {Array} Returns [run, isLoading] tuple
  */
 function useAsyncAction(asyncFn, options) {
+  console.log(`useAsyncAction is running with ${asyncFn}`); // entry log for tracing
   const mutation = useMutation({ // React Query mutation manages loading and caching
     mutationFn: async (...args) => asyncFn(...args), // delegate to caller provided function
     onSuccess: async (res) => { await options?.onSuccess?.(res); }, // trigger optional success side effects
@@ -192,8 +194,8 @@ function useAsyncAction(asyncFn, options) {
   const run = useCallback(
     (...args) => mutation.mutateAsync(...args), // call React Query mutation
     [mutation]
-  ); // expose stable trigger function
-
+  ); // stable trigger so components avoid re-render
+  console.log(`useAsyncAction is returning run and isPending ${mutation.isPending}`); // exit log for tracing
   return [run, mutation.isPending]; // expose loading state alongside runner
 }
 
@@ -220,6 +222,7 @@ function useAsyncAction(asyncFn, options) {
  * @returns {Object} Returns {items, isLoading, fetchData}
  */
 function useDropdownData(fetcher, toastFn, user) {
+  console.log(`useDropdownData is running with ${fetcher}`); // entry log for debugging
   if (!isFunction(fetcher)) { throw new Error('useDropdownData requires a function for `fetcher` parameter'); } // validate fetcher
   const queryKey = useMemo(() => ['dropdown', fetcher], [fetcher]); // stable key for React Query caching
 
@@ -234,10 +237,10 @@ function useDropdownData(fetcher, toastFn, user) {
   const fetchData = useCallback(
     () => queryClient.fetchQuery({ queryKey, queryFn: fetcher }), // manual refetch using React Query cache
     [queryKey, fetcher]
-  );
+  ); // stable refetch function so callers can refresh
 
   useEffect(() => { if (user) { fetchData(); } }, [user, fetchData, toastFn]); // run fetch after login
-
+  console.log(`useDropdownData is returning items length ${(data ?? []).length}`); // exit log for debugging
   return { items: data ?? [], isLoading: isPending, fetchData }; // normalized return shape for consumers
 }
 
@@ -646,6 +649,7 @@ function resetToastSystem() {
  * @returns {Array} Returns [run, isLoading] tuple
  */
 function useToastAction(asyncFn, successMsg, refresh) {
+  console.log(`useToastAction is running with ${asyncFn}`); // entry log for tracing
   const { toast } = useToast(); // acquire global toast dispatcher
   const callbacks = useMemo(
     () => ({ // memoize callbacks so reference stays stable
@@ -664,6 +668,7 @@ function useToastAction(asyncFn, successMsg, refresh) {
     [toast, successMsg, refresh]
   ); // recompute only when dependencies change
   const [run, isLoading] = useAsyncAction(asyncFn, callbacks); // wrap operation in library's loading pattern
+  console.log(`useToastAction is returning run and loading ${isLoading}`); // exit log for tracing
   return [run, isLoading]; // result tuple for caller convenience
 }
 


### PR DESCRIPTION
## Summary
- add entry/exit console logs to hooks: `useAsyncStateWithCallbacks`, `useAsyncAction`, `useDropdownData`, and `useToastAction`
- document rationale for callback creation and stable refetching

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684f34bd4af08322803b48668b4d7b9b