### PR TITLE
Enhance error handling logging

### DIFF
--- a/lib/errorHandling.js
+++ b/lib/errorHandling.js
@@ -24,21 +24,23 @@
  * @returns {*} Function result or throws transformed error
  */
 async function executeWithErrorHandling(fn, functionName, errorTransform) {
-  try { // attempt to execute the provided function
-    const result = await fn(); // run provided function
-    return result; // bubble result back to caller
-  } catch (error) { // catch and process function errors
+  console.log(`executeWithErrorHandling is running with ${functionName}`); // log entry context for debugging
+  try { // run the provided async function and capture its result
+    const result = await fn(); // execute caller function
+    console.log(`executeWithErrorHandling is returning ${result}`); // show resolved output for tracing
+    return result; // bubble result back to caller unchanged
+  } catch (error) { // handle errors thrown by the caller function
 
-    if (errorTransform && typeof errorTransform === 'function') { // caller wants custom error
-      const transformed = errorTransform(error); // let caller map error to custom type
-      if (transformed && typeof transformed.then === 'function') { // promise means async mapping
-        throw await transformed; // wait so stack shows transformed cause
+    if (errorTransform && typeof errorTransform === 'function') { // optional mapping lets caller customize error types
+      const transformed = errorTransform(error); // allow caller to wrap or augment the error
+      if (transformed && typeof transformed.then === 'function') { // async mapping preserves stack chain
+        throw await transformed; // rethrow transformed async error so upstream logic sees final message
       }
-      throw transformed; // throw mapped error so calling code handles specific type
+      throw transformed; // rethrow transformed sync error for caller awareness
     }
 
 
-    throw error; // rethrow unchanged to keep original stack when no transform
+    throw error; // rethrow original error to preserve stack when no transform supplied
 
   }
 }
@@ -58,17 +60,19 @@ async function executeWithErrorHandling(fn, functionName, errorTransform) {
  * @returns {*} Function result or throws transformed error
  */
 function executeSyncWithErrorHandling(fn, functionName, errorTransform) {
-  try { // run the synchronous function
-    const result = fn(); // run synchronous function
-    return result; // return directly
-  } catch (error) { // catch sync errors for uniform handling
+  console.log(`executeSyncWithErrorHandling is running with ${functionName}`); // log entry details for sync path
+  try { // run the synchronous function and capture result
+    const result = fn(); // execute the caller-provided function
+    console.log(`executeSyncWithErrorHandling is returning ${result}`); // expose returned value for tracing
+    return result; // return value directly as no async flow required
+  } catch (error) { // handle any synchronous error thrown by the function
 
-    if (errorTransform && typeof errorTransform === 'function') { // transformation allows caller context
-      throw errorTransform(error); // return caller's transformed error type
+    if (errorTransform && typeof errorTransform === 'function') { // allow calling code to reshape error before propagation
+      throw errorTransform(error); // rethrow transformed error so upstream logic knows specific issue
     }
 
 
-    throw error; // rethrow original to preserve stack if no transform
+    throw error; // rethrow original error when no transform is provided
 
   }
 }


### PR DESCRIPTION
## Summary
- log inputs and outputs for `executeWithErrorHandling`
- log inputs and outputs for `executeSyncWithErrorHandling`
- clarify error-handling rationale in comments

## Testing
- `node test.js` *(fails: Test suite output shows warnings about React `act()` and never completes)*

------
https://chatgpt.com/codex/tasks/task_b_684f34ba1d5483228b2da7dbdaf247c3