### PR TITLE
Fix getQueryFn 401 handler

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -220,11 +220,7 @@ function getQueryFn(options) { //(factory for query functions)
         axios.isAxiosError(err) &&
         err.response?.status === 401
       ) {
-
-        return null; // return null when optional query hits 401
-
-        return null; // return null rather than throwing when configured
-
+        return null; // return null when optional query hits 401 rather than throwing
       }
       throw formatAxiosError(err); // rethrow normalized error so calling code can handle consistently
     }


### PR DESCRIPTION
## Summary
- simplify getQueryFn 401 error handling

## Testing
- `node test-clean.js`

------
https://chatgpt.com/codex/tasks/task_b_684f34a77a088322b2e7a0d3808eaae7