### PR TITLE
Update toast cleanup docs

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -490,16 +490,17 @@ const actionTypes = {
  * 1. Canceling removal if toast is updated before timeout
  * 2. Preventing duplicate timeouts for the same toast
  * 3. Clean memory management by removing completed timeouts
+ *    when their callbacks fire so the map does not keep growing
  */
 const toastTimeouts = new Map(); // track removal timers per toast
 
 const addToRemoveQueue = (toastId) => { // schedule toast removal after delay
   if (toastTimeouts.has(toastId)) {
-    return; // duplicate calls are ignored to avoid multiple timers
+    return; // duplicate calls are ignored to prevent multiple timers per toast
   }
 
   const timeout = setTimeout(() => {
-    toastTimeouts.delete(toastId);
+    toastTimeouts.delete(toastId); // cleanup map to avoid memory growth during long sessions
     dispatch({
       type: "REMOVE_TOAST",
       toastId: toastId,


### PR DESCRIPTION
## Summary
- update comments on toast timeout removal

## Testing
- `npm test` *(fails: react-test-renderer deprecated warnings)*

------
https://chatgpt.com/codex/tasks/task_b_684faf07b5688322ba979640b9585163