### PR TITLE
docs(api): expand axiosClient baseURL comment

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -53,7 +53,7 @@ const { safeStringify } = require('./validation'); // import stringify helper fo
  * This instance should be used for all API requests to ensure consistency.
  */
 const axiosClient = axios.create({
-  baseURL: typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000', // use same host in browser and tests for convenience
+  baseURL: typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000', // window.location.origin hits current host; localhost fallback aids tests
   withCredentials: true, // always send cookies so session based auth works without extra config
   headers: { "Content-Type": "application/json" } // force JSON format which is the only payload this lib expects
 }); // single axios instance keeps interceptors and defaults identical everywhere


### PR DESCRIPTION
## Summary
- clarify the window.location.origin usage for the axiosClient baseURL

## Testing
- `npm test` *(fails to finish due to warnings about act and deprecated react-test-renderer)*

------
https://chatgpt.com/codex/tasks/task_b_684faf0dcab48322a7bed226a0ff6f00