### PR TITLE
Update withToastLogging comment

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -276,7 +276,7 @@ function logFunction(functionName, phase, data) { // unified logging helper
  * @param {Function} operation - The core operation to execute
  * @returns {Function} Wrapped function with logging and error handling
  */
-function withToastLogging(functionName, operation) { // wraps toast functions with logs
+function withToastLogging(functionName, operation) { // wraps toast functions with logs; introduces one stack frame yet removes per-call try/catch
   console.log(`withToastLogging is running with ${functionName}`); // trace wrapper creation
   const wrapped = function(...args) { // return a new function preserving API
     logFunction(functionName, 'entry', args[1] || 'params'); // start log for easier tracing


### PR DESCRIPTION
## Summary
- document trade-off in the withToastLogging wrapper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684faf12bca483228fe393e730f489db