### PR TITLE
docs(useDropdownData): clarify effect dependencies

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -248,7 +248,7 @@ function useDropdownData(fetcher, toastFn, user) {
     [queryKey, fetcher]
   ); // stable refetch function so callers can refresh
 
-  useEffect(() => { if (user) { fetchData(); } }, [user, fetchData, toastFn]); // run fetch after login
+  useEffect(() => { if (user) { fetchData(); } }, [user, fetchData, toastFn]); // run fetch after login; toastFn in deps causes refetch if a new toast is provided so errors show with new handler
   console.log(`useDropdownData is returning items length ${(data ?? []).length}`); // exit log for debugging
   return { items: data ?? [], isLoading: isPending, fetchData }; // normalized return shape for consumers
 }


### PR DESCRIPTION
## Summary
- clarify why `toastFn` is a dependency in `useDropdownData`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684faedf525c8322801c10d9d3027d07