### PR TITLE
docs(errorHandling): document async transform option

### DIFF
--- a/lib/errorHandling.js
+++ b/lib/errorHandling.js
@@ -32,6 +32,7 @@ async function executeWithErrorHandling(fn, functionName, errorTransform) {
   } catch (error) { // handle any thrown error
     if (errorTransform && typeof errorTransform === 'function') { // caller supplied mapper
       const transformed = errorTransform(error); // map original error to new one
+      // errorTransform may yield a Promise so async logging or reporting can run before rethrowing
       if (transformed && typeof transformed.then === 'function') { // mapper returned promise
         throw await transformed; // await promise to keep stack then rethrow
       }


### PR DESCRIPTION
## Summary
- document the optional Promise return from `errorTransform` in `executeWithErrorHandling`

## Testing
- `npm test` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_b_684faf0b07308322967bce9fea041ae6