### PR TITLE
docs(index): clarify export groupings

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const {
  * Keeping a single export block makes the API easy to scan by new consumers; ensures discoverability.
  * Internal modules can move or reorganize without changing these exports, so existing imports keep working; ensures backward compatibility.
  */
+// Exports are grouped by hook type: async actions, UI helpers, utilities, API // clarifies structure for maintainers
 module.exports = { // CommonJS export consolidating public API
   // Core async functionality hooks
   useAsyncAction,        // Primary hook for async operations with loading states // public so apps share one async pattern


### PR DESCRIPTION
## Summary
- add note that exports are grouped by hook type in `index.js`

## Testing
- `npm test` *(fails to finish in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_684faf0506608322902d34f6bd357a5e