### PR TITLE
Remove newline at start of toastIntegration

### DIFF
--- a/lib/toastIntegration.js
+++ b/lib/toastIntegration.js
@@ -1,4 +1,3 @@
-
 /**
  * Toast Integration Utilities Module
  * 


### PR DESCRIPTION
## Summary
- remove stray blank line at start of `toastIntegration.js`

## Testing
- `npm test` *(fails: Test 11 did not finish)*

------
https://chatgpt.com/codex/tasks/task_b_684faed190cc8322b6579a685e640109