### PR TITLE
Add helper hook exports and isolated tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@
 // Import all hooks, utilities, and API functions from the consolidated hooks module
 // The hooks module acts as an aggregator, pulling together functionality from multiple internal modules
 const {
+  executeWithLoadingState, // loading helper // imported for explicit export
+  useStableCallbackWithHandlers, // callback helper with handlers // imported for direct access
+  useAsyncStateWithCallbacks, // async state hook // imported to expose low level helper
+  useCallbackWithErrorHandling, // callback wrapper with errors // imported for completeness
   useAsyncAction, useDropdownData, createDropdownListHook, useDropdownToggle, // aggregate hook utilities // gathered here to ensure stable references across modules
   useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect, // UI-related helpers // centralizing UI hooks prevents scattered imports
   showToast, toastSuccess, toastError, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch // core API & toast utilities // exposes internal tools in one shot for clarity
@@ -38,6 +42,10 @@ const {
 // Exports are grouped by hook type: async actions, UI helpers, utilities, API // clarifies structure for maintainers
 module.exports = { // CommonJS export consolidating public API
   // Core async functionality hooks
+  executeWithLoadingState, // helper for toggling loading around promises // exposed for external composition
+  useStableCallbackWithHandlers, // callback with success/error handlers // exported for direct usage
+  useAsyncStateWithCallbacks, // async hook with callbacks // public to share low level pattern
+  useCallbackWithErrorHandling, // callback wrapper with error propagation // exported for consistency
   useAsyncAction,        // Primary hook for async operations with loading states // public so apps share one async pattern
   useToastAction,        // Combines async actions with toast updates // public so apps wire loading and toasts consistently
   

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -744,6 +744,10 @@ const { stopEvent } = require('./utils'); // event helper utilities
 const { apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient } = require('./api'); // API helpers and clients
 
 module.exports = { // consolidated export for entire hooks library
+  executeWithLoadingState, // async loading helper // exported for independent reuse
+  useStableCallbackWithHandlers, // callback with handlers // exposed for advanced patterns
+  useAsyncStateWithCallbacks, // async state hook with callbacks // public to share pattern
+  useCallbackWithErrorHandling, // callback wrapper with error propagation // exported for external use
   useAsyncAction,      // hook for async operations // public to share async pattern
   useDropdownData,     // manage dropdown state // exported so dropdown logic is reusable
   createDropdownListHook, // factory for typed dropdown hooks // public to allow custom dropdowns

--- a/test.js
+++ b/test.js
@@ -320,6 +320,8 @@ async function assertApiError(endpoint, expectedErrorPattern, testDescription) {
 
 // Import validation utilities after axios mock is in place so axios.isAxiosError uses the stub
 const { isFunction, isObject, safeStringify, isAxiosErrorWithStatus } = require('./lib/validation.js');
+// Load internal helper tests so they run within this suite
+require('./tests/internal-helpers.test.js')({ runTest, renderHook, assert, assertEqual });
 
 console.log('🚀 Starting Enhanced Comprehensive Test Suite...\n');
 

--- a/tests/internal-helpers.test.js
+++ b/tests/internal-helpers.test.js
@@ -1,0 +1,107 @@
+const React = require('react'); // React for hook execution
+const TestRenderer = require('react-test-renderer'); // renderer to run hooks
+
+module.exports = function helpersTests({ runTest, renderHook, assert, assertEqual }) {
+  const {
+    useStableCallbackWithHandlers,
+    useAsyncStateWithCallbacks,
+    useCallbackWithErrorHandling,
+    executeWithLoadingState
+  } = require('../lib/hooks.js'); // import functions under test
+
+  runTest('executeWithLoadingState resolves and toggles loading', async () => {
+    let loading = false; // tracks loading state changes
+    const setLoading = (v) => { loading = v; }; // mimic setState
+    const promise = executeWithLoadingState(setLoading, async () => 'ok');
+    assertEqual(loading, true, 'Loading should be true immediately');
+    const result = await promise; // wait for completion
+    assertEqual(result, 'ok', 'Should return result');
+    assertEqual(loading, false, 'Loading should be false after finish');
+  });
+
+  runTest('executeWithLoadingState propagates errors', async () => {
+    let loading = false;
+    const setLoading = (v) => { loading = v; };
+    let threw = false;
+    const err = new Error('fail');
+    try {
+      await executeWithLoadingState(setLoading, async () => { throw err; });
+    } catch (e) { threw = e === err; }
+    assert(threw, 'Original error should be thrown');
+    assertEqual(loading, false, 'Loading cleared on error');
+  });
+
+  runTest('useStableCallbackWithHandlers calls onSuccess', async () => {
+    let success;
+    const { result } = renderHook(() =>
+      useStableCallbackWithHandlers((v) => v + 1, { onSuccess: (r) => { success = r; } }, [])
+    );
+    const val = await result.current(1);
+    assertEqual(val, 2, 'Returned value should match');
+    assertEqual(success, 2, 'onSuccess receives result');
+  });
+
+  runTest('useStableCallbackWithHandlers handles errors', async () => {
+    let errOut;
+    const error = new Error('boom');
+    const { result } = renderHook(() =>
+      useStableCallbackWithHandlers(() => { throw error; }, { onError: (e) => { errOut = e; } }, [])
+    );
+    let threw = false;
+    try { await result.current(); } catch (e) { threw = e === error; }
+    assert(threw, 'Error should propagate');
+    assertEqual(errOut, error, 'onError receives error');
+  });
+
+  runTest('useAsyncStateWithCallbacks manages loading and callbacks', async () => {
+    let success;
+    let resolveFn;
+    const asyncFn = () => new Promise(res => { resolveFn = () => res(3); });
+    const { result } = renderHook(() =>
+      useAsyncStateWithCallbacks(asyncFn, { onSuccess: (r) => { success = r; } })
+    );
+    const [run] = result.current;
+    let promise;
+    TestRenderer.act(() => { promise = run(); });
+    assertEqual(result.current[1], true, 'isLoading true after run');
+    await TestRenderer.act(async () => { resolveFn(); await promise; });
+    assertEqual(result.current[1], false, 'isLoading false after run');
+    assertEqual(success, 3, 'onSuccess called with result');
+  });
+
+  runTest('useAsyncStateWithCallbacks propagates errors', async () => {
+    let errOut;
+    const error = new Error('oops');
+    const { result } = renderHook(() =>
+      useAsyncStateWithCallbacks(() => Promise.reject(error), { onError: (e) => { errOut = e; } })
+    );
+    let threw = false;
+    try { await result.current[0](); } catch (e) { threw = e === error; }
+    assert(threw, 'Error should propagate from run');
+    assertEqual(errOut, error, 'onError called with error');
+    assertEqual(result.current[1], false, 'Loading cleared after error');
+  });
+
+  runTest('useCallbackWithErrorHandling executes handlers', async () => {
+    let success;
+    const { result } = renderHook(() =>
+      useCallbackWithErrorHandling((v) => v * 2, { onSuccess: (r) => { success = r; } }, [])
+    );
+    const val = await result.current(2);
+    assertEqual(val, 4, 'Return value correct');
+    assertEqual(success, 4, 'onSuccess invoked');
+  });
+
+  runTest('useCallbackWithErrorHandling propagates error', async () => {
+    let errOut;
+    const error = new Error('err');
+    const { result } = renderHook(() =>
+      useCallbackWithErrorHandling(() => { throw error; }, { onError: (e) => { errOut = e; } }, [])
+    );
+    let threw = false;
+    try { await result.current(); } catch (e) { threw = e === error; }
+    assert(threw, 'Error should be thrown');
+    assertEqual(errOut, error, 'onError invoked with error');
+  });
+};
+


### PR DESCRIPTION
## Summary
- expose async utility helpers from `lib/hooks.js`
- re-export helpers from public API
- include new test file `tests/internal-helpers.test.js`
- load the new test suite from `test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fb9e1dad08322a5cc875747cb0d4e