### PR TITLE
Update setField to use updated object

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -363,8 +363,9 @@ function useEditForm(initialState) {
   // Individual field setter using functional update pattern to avoid stale closures
   function setField(key, value) {
     console.log(`setField is running with ${key}:${value}`); // inner helper log
-    setFields((prev) => ({ ...prev, [key]: value })); // merge new value to keep other fields intact
-    console.log(`setField has run resulting in a final value of ${JSON.stringify(fields)}`); // final log
+    const updated = { ...fields, [key]: value }; // create updated object for direct assignment
+    setFields(updated); // set new field values
+    console.log(`setField has run resulting in a final value of ${JSON.stringify(updated)}`); // final log
   }
 
   // Start editing an existing item by populating form fields with item data


### PR DESCRIPTION
## Summary
- adjust `setField` to use a precomputed updated object

## Testing
- `npm test` *(fails: An update to TestComponent inside a test was not wrapped in act...)*

------
https://chatgpt.com/codex/tasks/task_b_684fc29d00dc8322adafbcb062300d68