### PR TITLE
Update dispatch listener logic

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -580,7 +580,11 @@ let memoryState = { toasts: [] }; // simple in-memory store for global toast sta
 function dispatch(action) { // notify subscribers whenever toast state changes
   memoryState = reducer(memoryState, action); // apply update using reducer logic
   listeners.forEach((listener) => {
-    listener(memoryState); // publish new state to all listeners
+    try { // isolate listener errors so others still run
+      listener(memoryState); // publish new state to all listeners
+    } catch (error) {
+      console.log(error); // log listener failure but continue dispatch
+    }
   }); // end loop over listeners
 }
 


### PR DESCRIPTION
## Summary
- prevent a single failing toast listener from interrupting dispatch

## Testing
- `npm test` *(fails: An update to TestComponent inside a test was not wrapped in act)*

------
https://chatgpt.com/codex/tasks/task_b_684fc29881d083229fb56c4f9ad2a179