### PR TITLE
Fix SSR behavior in useIsMobile

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -428,7 +428,11 @@ const MOBILE_BREAKPOINT = 768; // 768px chosen to match common tablet breakpoint
  */
 function useIsMobile() {
   console.log(`useIsMobile is running`); // entry log for debugging
-  const result = useMediaQuery({ maxWidth: MOBILE_BREAKPOINT - 1 }); // library returns boolean directly
+  if (typeof window === 'undefined') { // check for server environment so window access doesn't throw
+    console.log(`useIsMobile is returning false`); // exit log for tracing when no window
+    return false; // default to desktop view when window object is missing
+  }
+  const result = useMediaQuery({ maxWidth: MOBILE_BREAKPOINT - 1 }); // library returns boolean directly when browser is available
   console.log(`useIsMobile is returning ${result}`); // exit log for tracing
   return result; // boolean indicating viewport size
 }


### PR DESCRIPTION
## Summary
- handle server environments in `useIsMobile`

## Testing
- `node test-simple.js`
- `node test-core.js` *(fails: showToast wrapper - showToast requires a function for `toast` parameter)*

------
https://chatgpt.com/codex/tasks/task_b_684fc29619b883228b30949feafb2c10