### PR TITLE
Update editing hooks to use useCallback

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -361,43 +361,32 @@ function useEditForm(initialState) {
   const [fields, setFields] = useState(initialState); // working copy of form fields
 
   // Individual field setter using functional update pattern to avoid stale closures
-  function setField(key, value) {
-    console.log(`setField is running with ${key}:${value}`); // inner helper log
-    const updated = { ...fields, [key]: value }; // create updated object for direct assignment
-    setFields(updated); // set new field values
-    console.log(`setField has run resulting in a final value of ${JSON.stringify(updated)}`); // final log
-  }
+  const setField = useCallback((key, value) => {
+    console.log(`setField is running with ${key}:${value}`); // log parameters for debugging
+    setFields(prev => { const updated = { ...prev, [key]: value }; console.log(`setField has run resulting in a final value of ${JSON.stringify(updated)}`); return updated; }); // functional update keeps reference stable
+  }, []); // no deps because setFields is stable
 
   // Start editing an existing item by populating form fields with item data
-  function startEdit(item) {
+  const startEdit = useCallback((item) => {
     console.log(`startEdit is running with ${JSON.stringify(item)}`); // log entry
     if (!item || !item._id) { // validate item presence before proceeding
       return; // exit early when item is missing or malformed
     }
     setEditingId(item._id); // track which row is currently editable
-    
-    // Start with initialState structure to ensure all expected fields are present
-    const newFields = { ...initialState }; // start with default shape
-    // Only copy properties that exist in both initialState and the item
-    // This prevents unexpected fields from being added to the form
-    Object.keys(newFields).forEach((key) => {
-      if (key in item) { // copy only known keys to avoid accidental extras
-        newFields[key] = item[key];
-      }
-    });
-    setFields(newFields); // update state with sanitized item data
+
+    const newFields = { ...initialState }; // default shape ensures all fields
+    Object.keys(newFields).forEach((key) => { if (key in item) { newFields[key] = item[key]; } }); // copy only known keys
+    setFields(newFields); // update with sanitized data
     console.log(`startEdit has run resulting in a final value of ${JSON.stringify(newFields)}`); // final log
-  }
+  }, [initialState]); // recreate when initialState changes
 
   // Cancel editing and reset form to initial state
-  function cancelEdit() {
+  const cancelEdit = useCallback(() => {
     console.log(`cancelEdit is running`); // entry log
     setEditingId(null); // no row in edit mode
-    // Reset to initialState provides a clean slate, useful for both canceling edits
-    // and preparing the form for creating new items
     setFields(initialState); // revert to default field values
     console.log(`cancelEdit has run resulting in a final value of ${JSON.stringify(initialState)}`); // final log
-  }
+  }, [initialState]); // recreate when initialState changes
 
   const result = { editingId, fields, setField, startEdit, cancelEdit }; // gather return values
   console.log(`useEditForm is returning ${JSON.stringify(result)}`); // exit log


### PR DESCRIPTION
## Summary
- refactor `useEditForm` helpers to use `useCallback`
- avoid stale closures when updating fields

## Testing
- `npm test` *(fails: TestComponent updates not wrapped in act)*

------
https://chatgpt.com/codex/tasks/task_b_6850367e901c83229de27d76d575831e