### PR TITLE
Fix showToast wrapper test

### DIFF
--- a/test-core.js
+++ b/test-core.js
@@ -100,9 +100,9 @@ test('toast notification creation', () => { // verifies basic toast fields
   assert(typeof result.dismiss === 'function', 'Should have dismiss function');
 });
 
-// Test 5: wrapper uses default toast implementation
-test('showToast wrapper', () => { // ensures a toast object is returned
-  const result = showToast('Test message');
+// Test 5: wrapper uses injected toast implementation
+test('showToast wrapper', () => { // ensures a toast object is returned using provided toast helper
+  const result = showToast(toast, 'Test message'); // pass exported toast so wrapper executes correctly
   assert(typeof result === 'object', 'Should return toast object');
   assert(typeof result.id === 'string', 'Should have id');
 });


### PR DESCRIPTION
## Summary
- inject the exported `toast` helper into the `showToast` test

## Testing
- `npm test` *(fails: output truncated, completion uncertain)*

------
https://chatgpt.com/codex/tasks/task_b_68503678207083229d048601dc185963