### PR TITLE
Fix setField state update

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -362,10 +362,12 @@ function useEditForm(initialState) {
 
   // Individual field setter using functional update pattern to avoid stale closures
   function setField(key, value) {
-    console.log(`setField is running with ${key}:${value}`); // inner helper log
-    const updated = { ...fields, [key]: value }; // create updated object for direct assignment
-    setFields(updated); // set new field values
-    console.log(`setField has run resulting in a final value of ${JSON.stringify(updated)}`); // final log
+    console.log(`setField is running with ${key}:${value}`); // log entry to track field updates
+    setFields(prev => { // use functional state update to avoid stale closures
+      const updated = { ...prev, [key]: value }; // merge new field with previous state for reliability
+      console.log(`setField has run resulting in a final value of ${JSON.stringify(updated)}`); // log updated state for debugging
+      return updated; // return new state object to React
+    });
   }
 
   // Start editing an existing item by populating form fields with item data

--- a/test.js
+++ b/test.js
@@ -1197,6 +1197,16 @@ runTest('useEditForm startEdit handles invalid item', () => {
   assertEqual(result.current.fields.title, 't', 'Fields should remain unchanged when _id missing');
 });
 
+runTest('useEditForm setField merges sequential updates', () => {
+  const { result } = renderHook(() => useEditForm({ name: '', age: 0 }));
+  TestRenderer.act(() => {
+    result.current.setField('name', 'Ann');
+    result.current.setField('age', 4);
+  });
+  assertEqual(result.current.fields.name, 'Ann', 'Name should merge');
+  assertEqual(result.current.fields.age, 4, 'Age should merge');
+});
+
 // =============================================================================
 // ERROR HANDLING TESTS
 // =============================================================================


### PR DESCRIPTION
## Summary
- avoid stale closures in `setField`
- test merging of sequential `setField` calls

## Testing
- `npm test` *(fails: An update to TestComponent inside a test was not wrapped in act)*

------
https://chatgpt.com/codex/tasks/task_b_685036741d088322a7ed6dfb3e8dc84e