### PR TITLE
Update showToast test

### DIFF
--- a/test-core.js
+++ b/test-core.js
@@ -100,9 +100,10 @@ test('toast notification creation', () => { // verifies basic toast fields
   assert(typeof result.dismiss === 'function', 'Should have dismiss function');
 });
 
-// Test 5: wrapper uses default toast implementation
-test('showToast wrapper', () => { // ensures a toast object is returned
-  const result = showToast('Test message');
+// Test 5: wrapper uses provided toast function
+test('showToast wrapper', () => { // ensures a toast object is returned with id
+  const mockToast = (params) => ({ id: 'mock-id', dismiss: () => {}, ...params }); // minimal mock to verify showToast delegation
+  const result = showToast(mockToast, 'Test message');
   assert(typeof result === 'object', 'Should return toast object');
   assert(typeof result.id === 'string', 'Should have id');
 });


### PR DESCRIPTION
## Summary
- mock the toast dependency for the `showToast` wrapper test

## Testing
- `node test-core.js`
- `node test-simple.js` *(fails: apiRequest basic functionality: 500)*

------
https://chatgpt.com/codex/tasks/task_b_68503665e2788322806d4f47ebe6b307