### PR TITLE
Fix refresh guard in useToastAction

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -704,8 +704,8 @@ function useToastAction(asyncFn, successMsg, refresh) {
     () => ({ // memoize callbacks so reference stays stable
     onSuccess: async (result) => {
       toastSuccess(toast, successMsg); // trigger success toast with provided message
-      if (refresh) { // optional refresh after success
-        await refresh();
+      if (isFunction(refresh)) { // ensure refresh is callable to avoid runtime errors
+        await refresh(); // run refresh callback after success when provided
       }
       return result;
     },

--- a/test.js
+++ b/test.js
@@ -1021,6 +1021,16 @@ runTest('useToastAction integrates async action with toast system', () => {
   assert(typeof testToast.id === 'string', 'Toast integration should work');
 });
 
+runTest('useToastAction skips refresh when not a function', async () => {
+  resetToastSystem(); // ensure clean toast state for the test
+  const { result } = renderHook(() => useToastAction(async () => 'ok', 'done', 'bad')); // pass invalid refresh value
+  let value;
+  await TestRenderer.act(async () => { value = await result.current[0](); }); // invoke run function
+  assertEqual(value, 'ok', 'Run should resolve original result');
+  const { result: toastResult } = renderHook(() => useToast()); // inspect toast state
+  assertEqual(toastResult.current.toasts.length, 1, 'Success toast should still appear');
+});
+
 runTest('API functions integrate with utility functions', async () => {
   // Test that apiRequest can be used with showToast
   const toastCalls = [];


### PR DESCRIPTION
## Summary
- ensure `refresh` callback in `useToastAction` is a function before calling
- add regression test for invalid `refresh` argument

## Testing
- `node test.js` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_b_685035c768c08322a7b32ad1aafdd5d8