### PR TITLE
Ensure getQueryFn defaults to throwing on 401

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -200,8 +200,8 @@ async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
  * @param {string} options.on401 - How to handle 401 errors ('returnNull' or 'throw')
  * @returns {Function} QueryFunction for React Query
  */
-function getQueryFn(options) { // produce a React Query function with built-in 401 logic
-  const { on401: unauthorizedBehavior } = options; // caller specifies how to treat unauthorized responses
+function getQueryFn(options = { on401: 'throw' }) { // default rejects on 401 so auth is required
+  const { on401: unauthorizedBehavior = 'throw' } = options; // fallback to throw when caller omits behavior
 
   return async ({ queryKey }) => { //(returned QueryFunction)
     try { // perform GET and manage 401s


### PR DESCRIPTION
## Summary
- set a default options argument for `getQueryFn`
- make unauthorized behavior fall back to `'throw'`

## Testing
- `npm test` *(fails to print full output but exits successfully)*

------
https://chatgpt.com/codex/tasks/task_b_6850364dfb2c8322891e1bdf7f5a5ac6