### PR TITLE
Update editForm setter and mobile hook

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -362,10 +362,9 @@ function useEditForm(initialState) {
 
   // Individual field setter using functional update pattern to avoid stale closures
   function setField(key, value) {
-    console.log(`setField is running with ${key}:${value}`); // inner helper log
-    const updated = { ...fields, [key]: value }; // create updated object for direct assignment
-    setFields(updated); // set new field values
-    console.log(`setField has run resulting in a final value of ${JSON.stringify(updated)}`); // final log
+    console.log(`setField is running with ${key}:${value}`); // entry log showing key/value pair
+    setFields(prev => { const updated = { ...prev, [key]: value }; return updated; }); // functional update prevents stale state
+    console.log(`setField has run resulting in a final value of ${JSON.stringify({ ...fields, [key]: value })}`); // log final result
   }
 
   // Start editing an existing item by populating form fields with item data
@@ -429,11 +428,10 @@ const MOBILE_BREAKPOINT = 768; // 768px chosen to match common tablet breakpoint
  */
 function useIsMobile() {
   console.log(`useIsMobile is running`); // entry log for debugging
-  if (typeof window === 'undefined') { // check for server environment so window access doesn't throw
-    console.log(`useIsMobile is returning false`); // exit log for tracing when no window
-    return false; // default to desktop view when window object is missing
-  }
-  const result = useMediaQuery({ maxWidth: MOBILE_BREAKPOINT - 1 }); // library returns boolean directly when browser is available
+  const result = useMediaQuery(
+    { maxWidth: MOBILE_BREAKPOINT - 1 },
+    typeof window === 'undefined' ? { width: MOBILE_BREAKPOINT + 1 } : undefined
+  ); // pass device width when SSR so hook doesn't rely on window
   console.log(`useIsMobile is returning ${result}`); // exit log for tracing
   return result; // boolean indicating viewport size
 }


### PR DESCRIPTION
## Summary
- avoid stale closures in `useEditForm` by using functional `setFields`
- ensure `useIsMobile` runs in SSR without checking `window`

## Testing
- `node test-simple.js` *(fails: apiRequest basic functionality)*
- `node test-core.js` *(fails: showToast wrapper)*

------
https://chatgpt.com/codex/tasks/task_b_68503651115483228ce5366018aa4a79