### PR TITLE
Ensure useMediaQuery runs server-side

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -418,11 +418,13 @@ const MOBILE_BREAKPOINT = 768; // 768px chosen to match common tablet breakpoint
  */
 function useIsMobile() {
   console.log(`useIsMobile is running`); // entry log for debugging
-  if (typeof window === 'undefined') { // check for server environment so window access doesn't throw
-    console.log(`useIsMobile is returning false`); // exit log for tracing when no window
-    return false; // default to desktop view when window object is missing
+  const queryOpts = { maxWidth: MOBILE_BREAKPOINT - 1 }; // settings for media query detection
+  const deviceOpts = typeof window === 'undefined' ? { width: MOBILE_BREAKPOINT } : undefined; // provide width for server rendering
+  const result = useMediaQuery(queryOpts, deviceOpts); // react-responsive works in all environments
+  if (typeof window === 'undefined') { // preserve existing return behavior when window missing
+    console.log(`useIsMobile is returning false`); // exit log consistent with original code
+    return false; // maintain default desktop result during SSR
   }
-  const result = useMediaQuery({ maxWidth: MOBILE_BREAKPOINT - 1 }); // library returns boolean directly when browser is available
   console.log(`useIsMobile is returning ${result}`); // exit log for tracing
   return result; // boolean indicating viewport size
 }


### PR DESCRIPTION
## Summary
- refactor `useIsMobile` to always call `useMediaQuery`
- keep existing behaviour for SSR by providing default width

## Testing
- `node test.js` *(fails: An update to TestComponent inside a test was not wrapped in act)*

------
https://chatgpt.com/codex/tasks/task_b_68505199c410832282a7c09adc1c5bc9