### PR TITLE
Expose toast feedback helpers through main API

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ Pre-configured Axios instance with authentication and JSON handling.
 ### showToast(toast, message, title, variant)
 Framework-agnostic toast creation utility.
 
+### executeWithErrorToast(operation, toast, errorTitle)
+Runs an async operation and shows a destructive toast when the operation throws. The original error is re-thrown for caller handling.
+
+### executeWithToastFeedback(operation, toast, successMessage, errorTitle)
+Runs an async operation and displays a success toast when it resolves or an error toast on failure.
+
 ### stopEvent(event)
 Combined preventDefault and stopPropagation utility for React events.
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const {
   useCallbackWithErrorHandling, // callback wrapper with errors // imported for completeness
   useAsyncAction, useDropdownData, createDropdownListHook, useDropdownToggle, // aggregate hook utilities // gathered here to ensure stable references across modules
   useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect, // UI-related helpers // centralizing UI hooks prevents scattered imports
-  showToast, toastSuccess, toastError, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch // core API & toast utilities // exposes internal tools in one shot for clarity
+  showToast, toastSuccess, toastError, executeWithErrorToast, executeWithToastFeedback, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch // core API & toast utilities // exposes internal tools in one shot for clarity
 } = require('./lib/hooks'); // CommonJS import keeps broad Node compatibility // require chosen so Node apps of any version can consume this module
 
 /**
@@ -67,6 +67,8 @@ module.exports = { // CommonJS export consolidating public API
   showToast,             // Helper for displaying toast messages // public so notifications can be fired from any module
   toastSuccess,          // Success toast utility // exported for simple success messages
   toastError,            // Error toast utility // public so error toasts share formatting
+  executeWithErrorToast, // Operation wrapper that shows error toast // public for consistency
+  executeWithToastFeedback, // Operation wrapper with success/error toasts // exposed to unify feedback
   stopEvent,             // Event handling utility for preventing default behavior // kept public for generic DOM helpers
   getToastListenerCount, // Allows tests to inspect active toast listeners // exported to help verify toast state
   resetToastSystem,      // Clears toast listeners between tests // public to reset global state in tests

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -18,6 +18,7 @@
 const { useState, useCallback, useEffect, useMemo } = require('react'); // add useMemo for stable callback objects
 const { useMutation, useQuery } = require('@tanstack/react-query'); // use React Query hooks for async operations
 const { showToast, toastSuccess, toastError } = require('./utils'); // toast utilities for consistent notifications
+const { executeWithErrorToast, executeWithToastFeedback } = require('./toastIntegration'); // toast wrappers used outside hooks
 const { isFunction } = require('./validation'); // import type guard for parameter validation
 
 const { nanoid } = require('nanoid'); // use nanoid for unique IDs to avoid global counter
@@ -761,6 +762,8 @@ module.exports = { // consolidated export for entire hooks library
   showToast,           // lower-level toast helper // exposed so any code can display toasts
   toastSuccess,        // success toast utility // public for consistent success messages
   toastError,          // error toast utility // exported for uniform error messages
+  executeWithErrorToast, // run async op with error toast // exported so any code can surface failures
+  executeWithToastFeedback, // run op with success/error toasts // public to standardize feedback
   stopEvent,           // preventDefault + stopPropagation // public utility used across modules
   apiRequest,          // axios wrapper // exported so external modules use shared request logic
   getQueryFn,          // React Query query helper // public to build queries with 401 support

--- a/test.js
+++ b/test.js
@@ -108,7 +108,7 @@ const { handle401Error, codexRequest, executeAxiosRequest } = require('./lib/api
 // Direct imports for internal utilities under test
 const { executeAsyncWithLogging, logFunction, withToastLogging } = require('./lib/utils.js'); // test logging helpers
 const { executeWithErrorHandling, executeSyncWithErrorHandling } = require('./lib/errorHandling.js'); // test error wrappers
-const { executeWithErrorToast, executeWithToastFeedback } = require('./lib/toastIntegration.js'); // test toast integration
+const { executeWithErrorToast, executeWithToastFeedback } = require('./index.js'); // verify toast wrappers exported from main module
 
 const mockedAxiosClient = mockAxios.create(); // Create axios stub instance for API calls
 axiosClient.request = mockedAxiosClient.request; // override request so api layer uses mock
@@ -346,7 +346,7 @@ runTest('All core hooks are exported as functions', () => {
 });
 
 runTest('All utility functions are exported', () => {
-  const utilities = ['toast', 'showToast', 'stopEvent'];
+  const utilities = ['toast', 'showToast', 'executeWithErrorToast', 'executeWithToastFeedback', 'stopEvent'];
   
   utilities.forEach(utilName => {
     const util = eval(utilName);


### PR DESCRIPTION
## Summary
- include toast feedback helpers in hooks aggregator
- re-export toast helpers from main entry
- document new exports
- ensure tests check for these utilities

## Testing
- `npm test --silent` *(fails: act warnings and truncated output)*

------
https://chatgpt.com/codex/tasks/task_b_685057669da88322aa4bfdb4f5fd62dc