### PR TITLE
Fix package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "workspace",
+  "name": "qreactutils",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "workspace",
+      "name": "qreactutils",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "workspace",
+  "name": "qreactutils",
   "version": "1.0.0",
   "description": "A comprehensive React hooks library providing common functionality for async actions, dropdown management, form editing, mobile detection, toast notifications, and authentication redirects.",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- rename package to `qreactutils`
- update lock file to match new package name

## Testing
- `node test.js` *(fails: An update to TestComponent inside a test was not wrapped in act)*

------
https://chatgpt.com/codex/tasks/task_b_68505f7521388322b29351f7fd31aafb