### PR TITLE
Fix mock status in apiRequest

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -177,7 +177,7 @@ async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
   try { // run request with offline fallback
     const response = await codexRequest(
       () => axiosClient.request({ url, method, data }), //perform request via shared axios instance
-      { data: { message: 'Mocked in Codex' } } //mocked response returned in offline mode
+      { status: 200, data: { message: 'Mocked in Codex' } } // include status so mock mirrors axios response and keeps offline response consistent
     );
 
     const result = response.data; //extract just the payload for caller


### PR DESCRIPTION
## Summary
- ensure `apiRequest` mock response has an HTTP status field

## Testing
- `npm test` *(fails to display final results due to repeated React act warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68505f627ea48322934fd96b7cebcc0e