### PR TITLE
Fix dropdown fetch error handling

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -263,7 +263,7 @@ function useDropdownData(fetcher, toastFn, user) {
 
     const userBecameTruthy = !prevUserRef.current && user; // detect login transition
     const toastChanged = prevToastRef.current !== toastFn; // detect toast function swap
-    if (userBecameTruthy || toastChanged) { fetchData(); } // refetch when conditions met
+    if (userBecameTruthy || toastChanged) { fetchData().catch(() => {}); } // swallow errors to avoid unhandled rejections while toast handler displays them
 
     prevUserRef.current = user; // update last user for next render
     prevToastRef.current = toastFn; // update last toast for next render


### PR DESCRIPTION
## Summary
- avoid unhandled promise rejection when dropdown data refreshes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68505f5ee0188322b87b875a337a967c