### PR TITLE
Update apiRequest GET handling

### DIFF
--- a/enhanced-tests.js
+++ b/enhanced-tests.js
@@ -52,14 +52,14 @@ function assert(condition, message) { // throw if expectation fails
 // Mock implementations // replace real modules so tests run offline
 const mockAxios = {
   create: () => ({
-    request: async ({ url, method, data }) => {
+    request: async ({ url, method, data, params }) => { // capture config for GET vs others // changed
       if (url.includes('/error')) {
         const error = new Error('Network error');
         error.isAxiosError = true;
         error.response = { status: 500, data: 'Server error' };
         throw error;
       }
-      return { data: { success: true, url, method, requestData: data }, status: 200 };
+      return { data: { success: true, url, method, requestData: data, requestParams: params }, status: 200 }; // expose params for assertions // changed
     },
     get: async (url) => ({ data: { success: true, url }, status: 200 })
   }),
@@ -193,9 +193,11 @@ runTest('formatAxiosError handles different error types', () => { // tests axios
 });
 
 runTest('apiRequest handles successful requests', async () => { // uses mocked axios
-  const result = await apiRequest('/api/test', 'GET');
+  const result = await apiRequest('/api/test', 'GET', { a: 2 }); // send data to confirm param usage // changed
   assert(typeof result === 'object', 'Should return object');
   assert(result.success === true, 'Should indicate success');
+  assert(result.requestParams.a === 2, 'Should send params on GET'); // new assertion
+  assert(result.requestData === undefined, 'Should not send body on GET'); // new assertion
 });
 
 runTest('getQueryFn creates valid query function', () => { // ensures callable

--- a/lib/api.js
+++ b/lib/api.js
@@ -175,8 +175,9 @@ function formatAxiosError(err) { // ensure all thrown errors are plain Error ins
 */
 async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
   try { // run request with offline fallback
+    const config = method === 'GET' ? { url, method, params: data } : { url, method, data }; // send data as query params for GET // changed
     const response = await codexRequest(
-      () => axiosClient.request({ url, method, data }), //perform request via shared axios instance
+      () => axiosClient.request(config), //perform request via shared axios instance // updated to use new config
       { status: 200, data: { message: 'Mocked in Codex' } } // include status so mock mirrors axios response and keeps offline response consistent
     );
 

--- a/test-simple.js
+++ b/test-simple.js
@@ -84,14 +84,14 @@ function renderHook(hookFn) { // run hook with react-test-renderer and return it
 // Mock axios for testing // prevents real HTTP requests during unit tests
 const mockAxios = {
   create: () => ({
-    request: async ({ url, method }) => {
+    request: async ({ url, method, data, params }) => { // capture request body and params for assertions // changed
       if (url.includes('/error')) {
         throw { isAxiosError: true, response: { status: 500, data: 'Server error' } };
       }
       if (url.includes('/401')) {
         throw { isAxiosError: true, response: { status: 401, data: 'Unauthorized' } };
       }
-      return { data: { success: true, url, method }, status: 200 };
+      return { data: { success: true, url, method, data, params }, status: 200 }; // expose config values for tests // changed
     }
   })
 };
@@ -176,8 +176,10 @@ runTest('formatAxiosError handles errors', () => { // converts axios error
 
 // verifies that apiRequest handles a simple GET using the mocked axios client
 runTest('apiRequest basic functionality', async () => { // makes mocked request
-  const result = await apiRequest('/api/test', 'GET');
+  const result = await apiRequest('/api/test', 'GET', { q: 1 }); // pass data to verify query params // changed
   assert(result.success === true, 'Should return success response');
+  assert(result.params.q === 1, 'Should send data as query params'); // new check
+  assert(result.data === undefined, 'Should not send request body for GET'); // new check
 });
 
 runTest('getQueryFn creates query function', () => { // factory returns function


### PR DESCRIPTION
## Summary
- ensure apiRequest sends params on GET requests
- extend axios stubs to capture params
- verify query params in apiRequest tests

## Testing
- `npm test` *(fails: react-test-renderer warnings)*

------
https://chatgpt.com/codex/tasks/task_b_685068f0413c8322ac8d4002d8220633