### PR TITLE
Fix dropdown refetch on user change

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -234,7 +234,7 @@ function useAsyncAction(asyncFn, options) {
 function useDropdownData(fetcher, toastFn, user) {
   console.log(`useDropdownData is running with ${fetcher}`); // entry log for debugging
   if (!isFunction(fetcher)) { throw new Error('useDropdownData requires a function for `fetcher` parameter'); } // validate fetcher
-  const queryKey = useMemo(() => ['dropdown', fetcher], [fetcher]); // stable key for React Query caching
+  const queryKey = useMemo(() => ['dropdown', fetcher, user && user._id], [fetcher, user && user._id]); // include user id so cache resets per user
 
   const { data, isPending } = useQuery({ // query remote data via React Query
     queryKey, // unique cache key so data persists across mounts
@@ -261,9 +261,9 @@ function useDropdownData(fetcher, toastFn, user) {
       return; // exit without fetching
     }
 
-    const userBecameTruthy = !prevUserRef.current && user; // detect login transition
+    const userChanged = prevUserRef.current?._id !== user?._id; // detect new user regardless of truthiness
     const toastChanged = prevToastRef.current !== toastFn; // detect toast function swap
-    if (userBecameTruthy || toastChanged) { fetchData().catch(() => {}); } // swallow errors to avoid unhandled rejections while toast handler displays them
+    if (userChanged || toastChanged) { fetchData().catch(() => {}); } // refetch when user or toast changes
 
     prevUserRef.current = user; // update last user for next render
     prevToastRef.current = toastFn; // update last toast for next render


### PR DESCRIPTION
## Summary
- ensure useDropdownData query key tracks user id
- refetch dropdown data whenever user changes
- test useDropdownData user switch refetch logic

## Testing
- `npm test --silent` *(fails: An update to TestComponent inside a test was not wrapped in act...)*

------
https://chatgpt.com/codex/tasks/task_b_685068f8dbfc83229f6a7b1d42e0305c