### PR TITLE
Fix dropdown fetch condition

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -263,7 +263,7 @@ function useDropdownData(fetcher, toastFn, user) {
 
     const userBecameTruthy = !prevUserRef.current && user; // detect login transition
     const toastChanged = prevToastRef.current !== toastFn; // detect toast function swap
-    if (userBecameTruthy || toastChanged) { fetchData().catch(() => {}); } // swallow errors to avoid unhandled rejections while toast handler displays them
+    if (userBecameTruthy || (toastChanged && user)) { fetchData().catch(() => {}); } // fetch on login or when toast changes with a valid user only to avoid network calls pre-auth
 
     prevUserRef.current = user; // update last user for next render
     prevToastRef.current = toastFn; // update last toast for next render

--- a/test.js
+++ b/test.js
@@ -1104,6 +1104,22 @@ runTest('useDropdownData refetches when toast changes', async () => {
   assertEqual(calls, 2, 'Fetch should run again when toast instance changes');
 });
 
+runTest('useDropdownData does not refetch when toast changes with no user', async () => {
+  let calls = 0; // track fetcher usage when user absent
+  const fetcher = async () => { calls++; return ['z']; }; // simple fetcher for test
+
+  const { rerender } = renderHook(
+    (p) => useDropdownData(fetcher, p.toast, null),
+    { toast: () => {} }
+  ); // mount without user
+  await TestRenderer.act(async () => { await Promise.resolve(); }); // wait; should not fetch
+  assertEqual(calls, 0, 'No fetch should run without user');
+
+  rerender({ toast: () => {} }); // update toast while user still null
+  await TestRenderer.act(async () => { await Promise.resolve(); }); // allow effect to run
+  assertEqual(calls, 0, 'Toast change should not trigger fetch without user');
+});
+
 runTest('useDropdownData fetches once when user present at mount', async () => {
   let calls = 0; // track fetcher executions
   const fetcher = async () => { calls++; return ['x']; }; // simple fetcher


### PR DESCRIPTION
## Summary
- execute dropdown fetch only when user exists or just logged in
- test toast changes with no user

## Testing
- `npm test` *(fails: An update to TestComponent inside a test was not wrapped in act warnings, truncated output)*

------
https://chatgpt.com/codex/tasks/task_b_685068eee17083229d53ebc1d3fac48e