### PR TITLE
Improve toast logging for async operations

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -281,16 +281,24 @@ function withToastLogging(functionName, operation) { // wraps toast functions wi
   console.log(`withToastLogging is running with ${functionName}`); // trace wrapper creation
   const wrapped = function(...args) { // return a new function preserving API
     logFunction(functionName, 'entry', args[1] || 'params'); // start log for easier tracing
+    let result; // store operation outcome for inspection
     try { // attempt to run the original operation
-
-      const result = operation.apply(this, args); // invoke underlying toast logic
-      logFunction(functionName, 'exit', result); // log final toast object
-      return result; // ensure wrapped function mirrors original API
-    } catch (err) { // capture any errors
-      logFunction(functionName, 'error', err); // pass error object for detailed logging
-      throw err; // rethrow so calling code can handle failure
-
-    } // end catch
+      result = operation.apply(this, args); // invoke underlying toast logic
+    } catch (err) { // capture any synchronous errors
+      logFunction(functionName, 'error', err); // log sync error immediately for debugging
+      throw err; // propagate failure to caller
+    }
+    if (result && typeof result.then === 'function') { // detect promise so we can log when it resolves
+      return result.then((res) => { // attach logging on success
+        logFunction(functionName, 'exit', res); // log resolved value after async completion
+        return res; // maintain wrapped return contract as resolved value
+      }).catch((err) => { // handle async errors
+        logFunction(functionName, 'error', err); // log rejection for consistent tracing
+        throw err; // propagate rejection
+      });
+    }
+    logFunction(functionName, 'exit', result); // log final toast object for synchronous case
+    return result; // ensure wrapped function mirrors original API
   }; // end wrapper
   console.log(`withToastLogging is returning wrapped function`); // log returned wrapper
   return wrapped; // expose new function for callers

--- a/test.js
+++ b/test.js
@@ -569,6 +569,20 @@ runTest('withToastLogging wraps function and preserves errors', () => {
   assert(threw, 'Wrapped errors should propagate');
 });
 
+runTest('withToastLogging handles async rejection', async () => {
+  const messages = [];
+  const orig = console.log;
+  console.log = (msg) => { messages.push(msg); };
+  const asyncWrap = withToastLogging('asyncToast', () => Promise.reject(new Error('bad')));
+  const promise = asyncWrap();
+  let threw = false;
+  try { await promise; } catch (e) { threw = e && e.message === 'bad'; }
+  console.log = orig;
+  assertEqual(typeof promise.then, 'function', 'Wrapped function should return Promise');
+  assert(threw, 'Wrapped async errors should propagate');
+  assert(messages.some(m => m.includes('asyncToast encountered error')), 'Should log rejection');
+});
+
 // =============================================================================
 // UNIT TESTS - VALIDATION UTILITIES
 // =============================================================================


### PR DESCRIPTION
## Summary
- enhance `withToastLogging` to support async operations by logging when promises resolve or reject
- test async rejection scenario for `withToastLogging`

## Testing
- `npm test` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_b_68506cfeea14832285e7611b60363bb4