### PR TITLE
Fix GET params handling

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -175,7 +175,14 @@ function formatAxiosError(err) { // ensure all thrown errors are plain Error ins
 */
 async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
   try { // run request with offline fallback
-    const config = method === 'GET' ? { url, method, params: data } : { url, method, data }; // send data as query params for GET // changed
+    const config = { url, method }; // base config used for all requests // changed
+    if (method === 'GET') { // treat GET differently so body isn't sent // added
+      if (data !== null && data !== undefined) { // only attach params when data exists // added
+        config.params = data; // map data to query params when provided // added
+      }
+    } else {
+      config.data = data; // send body for non-GET requests // added
+    }
     const response = await codexRequest(
       () => axiosClient.request(config), //perform request via shared axios instance // updated to use new config
       { status: 200, data: { message: 'Mocked in Codex' } } // include status so mock mirrors axios response and keeps offline response consistent

--- a/test.js
+++ b/test.js
@@ -681,6 +681,12 @@ runTest('apiRequest with different HTTP methods and data', async () => {
   assert(getResult.method === 'GET', 'Should use correct method');
   assert(getResult.requestParams.q === 2, 'Should send params for GET'); // new check
   assert(getResult.requestData === undefined, 'Should not send body for GET'); // new check
+
+  // Test GET request without data
+  const emptyGet = await apiRequest('/api/test', 'GET'); // omit data to verify params handling // added
+  assert(emptyGet.success === true, 'GET without data should succeed'); // added
+  assert(emptyGet.requestParams === undefined, 'Should not send params when data missing'); // added
+  assert(emptyGet.requestData === undefined, 'Should not send body when data missing'); // added
   
   // Test POST request with data
   const postData = { name: 'test', value: 123 };


### PR DESCRIPTION
## Summary
- build GET configs only when data is provided
- test apiRequest with no query data

## Testing
- `npm test --silent` *(fails: log output truncated)*

------
https://chatgpt.com/codex/tasks/task_b_68506ce386ec8322a5058424bd3dca23