### PR TITLE
Normalize method casing in apiRequest

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -175,7 +175,8 @@ function formatAxiosError(err) { // ensure all thrown errors are plain Error ins
 */
 async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
   try { // run request with offline fallback
-    const config = method === 'GET' ? { url, method, params: data } : { url, method, data }; // send data as query params for GET // changed
+    const normalizedMethod = method.toUpperCase(); // normalize so 'get' behaves like 'GET' // new logic
+    const config = normalizedMethod === 'GET' ? { url, method: normalizedMethod, params: data } : { url, method: normalizedMethod, data }; // send data as query params for GET // changed
     const response = await codexRequest(
       () => axiosClient.request(config), //perform request via shared axios instance // updated to use new config
       { status: 200, data: { message: 'Mocked in Codex' } } // include status so mock mirrors axios response and keeps offline response consistent

--- a/test.js
+++ b/test.js
@@ -694,6 +694,13 @@ runTest('apiRequest with different HTTP methods and data', async () => {
   assertEqual(defaultResult.method, 'POST', 'Should default to POST method');
 });
 
+runTest('apiRequest handles lowercase method', async () => {
+  const upperRes = await apiRequest('/api/test', 'GET', { q: 5 }); // baseline uppercase method
+  const lowerRes = await apiRequest('/api/test', 'get', { q: 5 }); // same call using lowercase method
+  assertEqual(JSON.stringify(lowerRes), JSON.stringify(upperRes), 'Lowercase method should behave like uppercase');
+  assert(lowerRes.method === 'GET', 'Method should be normalized to uppercase');
+});
+
 runTest('apiRequest error handling scenarios', async () => {
   // Test 500 error
   try {


### PR DESCRIPTION
## Summary
- normalize HTTP method to uppercase in `apiRequest`
- verify lowercase request method works in tests

## Testing
- `npm test` *(fails: Test runner ended unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_b_68506cf6b0088322a331e5a582753324