### PR TITLE
Fix logging data in async wrapper

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,10 +29,13 @@ const { safeStringify } = require('./validation.js'); // import safe-json-string
  * @param {string} operationName - Name for logging purposes
  * @param {Function} errorHandler - Optional custom error handler
  * @returns {Promise} Result of the operation or re-throws error
+ * The entry log records the wrapped operation's source to provide context on the
+ * function being executed, rather than repeating the operation name.
  */
 async function executeAsyncWithLogging(operation, operationName, errorHandler) { // wrapper for async ops with unified logs
   console.log(`executeAsyncWithLogging is running with ${operationName}`); // trace parameters for debugging
-  logFunction(operationName, 'entry', operationName); // record the call for debugging
+  // include stringified operation so logs reveal the actual function being executed
+  logFunction(operationName, 'entry', operation && operation.toString ? operation.toString() : 'operation function'); // record the wrapped function for debugging
   try { // attempt to run provided operation
 
     const result = await operation(); // execute provided async operation


### PR DESCRIPTION
## Summary
- log the wrapped function in `executeAsyncWithLogging` instead of repeating the name
- clarify comment that entry logs now show the function source

## Testing
- `npm test` *(fails: output truncated, warnings about react-test-renderer)*

------
https://chatgpt.com/codex/tasks/task_b_685071386a7c8322a171cc9d5b40aec0