### PR TITLE
Guard dropdown fetch by user presence

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -220,7 +220,8 @@ function useAsyncAction(asyncFn, options) {
  * - Takes a 'fetcher' function rather than a URL to allow for complex API calls,
  *   authentication headers, data transformation, etc.
  * - Depends on a 'user' object to trigger fetching, implementing the common pattern
- *   where data should only be fetched after authentication is confirmed
+ *   where data should only be fetched after authentication is confirmed. The effect
+ *   below also ensures refetching only occurs when a truthy user object is present
  * - Returns both items and a manual fetchData function, allowing for both automatic
  *   loading and manual refresh capabilities
  * - Integrates with toast system for user-friendly error messaging
@@ -261,9 +262,9 @@ function useDropdownData(fetcher, toastFn, user) {
       return; // exit without fetching
     }
 
-    const userChanged = prevUserRef.current?._id !== user?._id; // detect new user regardless of truthiness
+    const userChanged = prevUserRef.current?._id !== user?._id; // detect new user or sign out
     const toastChanged = prevToastRef.current !== toastFn; // detect toast function swap
-    if (userChanged || toastChanged) { fetchData().catch(() => {}); } // refetch when user or toast changes
+    if (user && (userChanged || toastChanged)) { fetchData().catch(() => {}); } // refetch only when user exists
 
     prevUserRef.current = user; // update last user for next render
     prevToastRef.current = toastFn; // update last toast for next render

--- a/tests/internal-helpers.test.js
+++ b/tests/internal-helpers.test.js
@@ -112,7 +112,7 @@ module.exports = function helpersTests({ runTest, renderHook, assert, assertEqua
 
     const { rerender } = renderHook(
       (p) => useDropdownData(fetcher, null, p.user), // hook under test with user prop
-      { user: { _id: 'u1' } } // initial user id
+      { user: { _id: 'u3' } } // initial user id unique per test
     );
     await TestRenderer.act(async () => { await Promise.resolve(); }); // allow initial query
     assertEqual(calls, 1, 'Should fetch once for first user');
@@ -120,6 +120,22 @@ module.exports = function helpersTests({ runTest, renderHook, assert, assertEqua
     rerender({ user: { _id: 'u2' } }); // update user id
     await TestRenderer.act(async () => { await Promise.resolve(); }); // trigger effect
     assertEqual(calls, 2, 'Should refetch for new user');
+  });
+
+  runTest('useDropdownData does not fetch when user becomes undefined', async () => {
+    let calls = 0; // track fetcher invocations for assertion
+    const fetcher = async () => { calls++; return ['i']; }; // simple fetcher returning data
+
+    const { rerender } = renderHook(
+      (p) => useDropdownData(fetcher, null, p.user), // hook under test with user prop
+      { user: { _id: 'u4' } } // initial user id unique from other tests
+    );
+    await TestRenderer.act(async () => { await Promise.resolve(); }); // allow initial query
+    assertEqual(calls, 1, 'Should fetch once for first user');
+
+    rerender({ user: undefined }); // simulate logout
+    await TestRenderer.act(async () => { await Promise.resolve(); }); // effect should not refetch
+    assertEqual(calls, 1, 'Should not refetch after user removed');
   });
 
   runTest('executeWithErrorHandling wraps non-error transform', async () => {


### PR DESCRIPTION
## Summary
- refetch dropdown data only when a user exists
- adjust docs explaining user requirement
- add regression test to ensure no fetch on sign out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850711fff2c832293dca5a1c43c9486