### PR TITLE
Ensure axios stub has create and isAxiosError

### DIFF
--- a/test-setup.js
+++ b/test-setup.js
@@ -6,7 +6,13 @@ try { require('qtests/setup'); } catch (error) { // qtests provides axios/winsto
   qtestsAvailable = false; // qtests missing so we fall back to simple mocks
   console.log('test-setup: using local stubs because qtests is missing'); // log fallback so devs know why
   const Module = require('module'); // node module loader reference for patching to return stubs
-  const axiosStub = { get: async () => ({}), post: async () => ({}) }; // stub mimics axios to avoid real HTTP traffic during tests
+  const axiosStub = {
+    get: async () => ({}), // resolves with empty object so callers see successful GET
+    post: async () => ({}), // resolves with empty object so POST based tests stay offline
+    request: async () => ({}) // generic request handler used by axios.create instances
+  }; // stub mimics axios to avoid real HTTP traffic during tests
+  axiosStub.create = () => ({ request: axiosStub.request, get: axiosStub.get, post: axiosStub.post }); // mirrors axios.create returning stub methods for early imports
+  axiosStub.isAxiosError = (error) => error && error.isAxiosError === true; // helps formatAxiosError detect stubbed axios errors
   const winstonStub = { createLogger: () => ({ info: () => {}, error: () => {}, debug: () => {} }), format: { combine: () => {}, timestamp: () => {}, json: () => {}, printf: () => {}, errors: () => {}, splat: () => {} }, transports: { Console: function () {}, File: function () {} } }; // lightweight winston stub to silence logging
   const originalLoad = Module._load; // preserve original loader for other modules before patching
   Module._load = function patchedLoad(request, parent, isMain) { // intercept requires so axios/winston return stubs rather than real modules


### PR DESCRIPTION
## Summary
- extend fallback axios stub in test setup with `create` and `isAxiosError`

## Testing
- `node test-core.js`
- `node test.js` *(fails: The command timed out or produced too much output)*

------
https://chatgpt.com/codex/tasks/task_b_6850715421f083228d7de39b0b02177a