### PR TITLE
Fix dropdown query key

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Generic React hook for managing dropdown state via a React Query `useQuery` call
 - `user` (Object): User object that triggers data fetch when available
 
 Data loads automatically when the `user` argument becomes truthy and refreshes if a new `toast` function is supplied after mount. The hook skips duplicate fetches on the initial render so a user provided at mount triggers only the React Query request.
+The React Query cache key uses `['dropdown', fetcher.name, user && user._id]` so the key is JSON serializable and predictable across renders.
 
 **Returns:** Object - `{items, isLoading, fetchData}`
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -225,6 +225,7 @@ function useAsyncAction(asyncFn, options) {
  *   loading and manual refresh capabilities
  * - Integrates with toast system for user-friendly error messaging
  * - Uses async/await with proper error handling and loading state management
+ * - Cache key includes `fetcher.name` so React Query can serialize the key
  * 
  * @param {Function} fetcher - Function that returns a Promise of array data
  * @param {Object} toast - Toast instance for error notifications
@@ -234,7 +235,8 @@ function useAsyncAction(asyncFn, options) {
 function useDropdownData(fetcher, toastFn, user) {
   console.log(`useDropdownData is running with ${fetcher}`); // entry log for debugging
   if (!isFunction(fetcher)) { throw new Error('useDropdownData requires a function for `fetcher` parameter'); } // validate fetcher
-  const queryKey = useMemo(() => ['dropdown', fetcher, user && user._id], [fetcher, user && user._id]); // include user id so cache resets per user
+  // use fetcher.name so key is JSON serializable for React Query caching
+  const queryKey = useMemo(() => ['dropdown', fetcher.name, user && user._id], [fetcher.name, user && user._id]); // include user id so cache resets per user with function name
 
   const { data, isPending } = useQuery({ // query remote data via React Query
     queryKey, // unique cache key so data persists across mounts

--- a/test.js
+++ b/test.js
@@ -1152,6 +1152,14 @@ runTest('useDropdownData fetches when user becomes truthy', async () => {
   assertEqual(calls, 1, 'Fetch should run after user becomes available');
 });
 
+runTest('useDropdownData caches with function name key', async () => {
+  async function namedFetcher() { return ['z']; }
+  renderHook(() => useDropdownData(namedFetcher, null, { _id: 'user' }));
+  await TestRenderer.act(async () => { await Promise.resolve(); });
+  const cached = queryClient.getQueryData(['dropdown', namedFetcher.name, 'user']);
+  assert(Array.isArray(cached) && cached[0] === 'z', 'Data should be cached under serializable key');
+});
+
 runTest('useDropdownData skips toast error when not a function', async () => {
   const fetcher = async () => { throw new Error('fail'); };
   const { result } = renderHook(() => useDropdownData(fetcher, 'text', { id: 'u3' }));


### PR DESCRIPTION
## Summary
- serialize `useDropdownData` query key using `fetcher.name`
- document new key behaviour
- test caching with named query key

## Testing
- `node test-core.js`
- `node test-simple.js` *(fails: apiRequest basic functionality)*
- `node tests/internal-helpers.test.js` *(no output)*

------
https://chatgpt.com/codex/tasks/task_b_6850715a21308322a92ac2c9bfa5e18e