### PR TITLE
Implement production log guard

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -238,6 +238,7 @@ function stopEvent(e) { // cancel browser event reliably
  * @param {*} data - Data to log (parameters, return values, errors)
  */
 function logFunction(functionName, phase, data) { // unified logging helper
+  if (process.env.NODE_ENV === 'production') { return; } // skip logging in prod for cleaner output
   console.log(`logFunction is running with ${functionName},${phase}`); // trace parameters for debugging
   switch (phase) { // branch on execution phase for clarity
     case 'entry': // starting function

--- a/test.js
+++ b/test.js
@@ -567,6 +567,21 @@ runTest('logFunction handles undefined without throwing', () => {
   assert(messages.some(m => m.includes('undefFn is returning')), 'Should log return for undefined');
 });
 
+runTest('logFunction does not log in production', () => {
+  const messages = [];
+  const origLog = console.log;
+  const origEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production'; // simulate production env
+  console.log = (msg) => { messages.push(msg); }; // capture logs
+
+  logFunction('prodFn', 'entry', 'p'); // should not output
+  logFunction('prodFn', 'exit', 'r');
+
+  console.log = origLog;
+  process.env.NODE_ENV = origEnv; // restore environment
+  assertEqual(messages.length, 0, 'No logs in production mode');
+});
+
 runTest('withToastLogging wraps function and preserves errors', () => {
   const calls = [];
   const wrapped = withToastLogging('demo', (t, msg) => { calls.push(msg); return 'done'; });


### PR DESCRIPTION
## Summary
- prevent logFunction from logging when NODE_ENV is production
- test that production mode skips logging

## Testing
- `npm test` *(fails: react act warnings spamming output)*

------
https://chatgpt.com/codex/tasks/task_b_68507f6c2f188322b5340f48b4738f65