### PR TITLE
Handle logout in dropdown hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Generic React hook for managing dropdown state via a React Query `useQuery` call
 
 Data loads automatically when the `user` argument becomes truthy and refreshes if a new `toast` function is supplied after mount. The hook skips duplicate fetches on the initial render so a user provided at mount triggers only the React Query request.
 The React Query cache key uses `['dropdown', fetcher.name, user && user._id]` so the key is JSON serializable and predictable across renders.
+If `user` becomes falsy after data has loaded the hook clears the cached query and returns an empty array so dropdowns reset when logging out.
 
 **Returns:** Object - `{items, isLoading, fetchData}`
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -267,9 +267,15 @@ function useDropdownData(fetcher, toastFn, user) {
     const toastChanged = prevToastRef.current !== toastFn; // detect toast function swap for updates
     if (userIdChanged || toastChanged) { fetchData().catch(() => {}); } // refetch when user id or toast fn changed
 
+    if (!user && prevUserRef.current) { // user logged out so clear cached data
+      const prevKey = ['dropdown', fetcher.name, prevUserRef.current._id]; // compute previous query key
+      queryClient.removeQueries({ queryKey: prevKey }); // drop stale cache tied to old user
+      queryClient.setQueryData(queryKey, []); // ensure items state resets to empty array
+    }
+
     prevUserRef.current = user; // update last user for next render
     prevToastRef.current = toastFn; // update last toast for next render
-  }, [user, toastFn, fetchData]); // dependencies ensure effect runs when inputs change
+  }, [user, toastFn, fetchData, queryKey]); // dependencies ensure effect runs when inputs or key change
   console.log(`useDropdownData is returning items length ${(data ?? []).length}`); // exit log for debugging
   return { items: data ?? [], isLoading: isPending, fetchData }; // normalized return shape for consumers
 }

--- a/tests/internal-helpers.test.js
+++ b/tests/internal-helpers.test.js
@@ -122,6 +122,22 @@ module.exports = function helpersTests({ runTest, renderHook, assert, assertEqua
     assertEqual(calls, 2, 'Should refetch for new user');
   });
 
+  runTest('useDropdownData clears items when user becomes null', async () => {
+    let calls = 0; // count fetcher runs for cache validation
+    const fetcher = async () => { calls++; return ['x']; }; // fetch returns single item
+
+    const { result, rerender } = renderHook(
+      (p) => useDropdownData(fetcher, null, p.user), // hook with user prop to control auth
+      { user: { _id: 'u1' } }
+    );
+    await TestRenderer.act(async () => { await Promise.resolve(); }); // allow initial query
+    assertEqual(result.current.items.length, 1, 'Should load item for user');
+
+    rerender({ user: null }); // simulate logout
+    await TestRenderer.act(async () => { await Promise.resolve(); }); // allow effect cleanup
+    assertEqual(result.current.items.length, 0, 'Items should reset when user is null');
+  });
+
   runTest('executeWithErrorHandling wraps non-error transform', async () => {
     const errFn = async () => { throw new Error('orig'); }; // function that throws
     try {


### PR DESCRIPTION
## Summary
- clear dropdown data on logout in useDropdownData
- document logout behavior
- test clearing dropdown items when user becomes null

## Testing
- `npm test --silent` *(fails: Test suite reported errors)*

------
https://chatgpt.com/codex/tasks/task_b_68507f63bac883228c6b05e382174567