### PR TITLE
Fix stopEvent validation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -211,7 +211,8 @@ function toastSuccess(toast, message, title = `Success`) { // wrapper for succes
  * @throws {Error} Re-throws any errors to preserve debugging information
  */
 function stopEvent(e) { // cancel browser event reliably
-  console.log(`stopEvent is running with ${e.type}`); // trace event type to debug unexpected interactions
+  if (!e || typeof e.preventDefault !== 'function' || typeof e.stopPropagation !== 'function') { throw new Error('Invalid event object'); } // ensure event object has required methods for consistent behaviour
+  console.log(`stopEvent is running with ${e.type}`); // trace event type to debug unexpected interactions after validation
   try { // attempt to cancel event
     // Prevent the browser's default action for this event, like submitting a form or navigating away
     e.preventDefault(); // stop browser default behaviour before custom handling

--- a/test.js
+++ b/test.js
@@ -453,15 +453,15 @@ runTest('stopEvent comprehensive behavior', () => {
 });
 
 runTest('stopEvent edge cases and error conditions', () => {
-  // Test with missing methods
-  assertThrows(() => {
-    stopEvent({});
-  }, 'Should throw when preventDefault missing');
-  
-  assertThrows(() => {
-    stopEvent({ preventDefault: () => {} });
-  }, 'Should throw when stopPropagation missing');
-  
+  // Test with missing methods triggers validation error
+  let err;
+  try { stopEvent({}); } catch (e) { err = e; }
+  assertEqual(err && err.message, 'Invalid event object', 'Should throw when preventDefault missing');
+
+  err = null;
+  try { stopEvent({ preventDefault: () => {} }); } catch (e) { err = e; }
+  assertEqual(err && err.message, 'Invalid event object', 'Should throw when stopPropagation missing');
+
   // Test with methods that throw
   assertThrows(() => {
     stopEvent({


### PR DESCRIPTION
## Summary
- validate event object in `stopEvent`
- update tests for new `stopEvent` error handling

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_b_68507f4993ec8322a2161ab51c6263c8