### PR TITLE
Improve dropdown key stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Generic React hook for managing dropdown state via a React Query `useQuery` call
 - `user` (Object): User object that triggers data fetch when available
 
 Data loads automatically when the `user` argument becomes truthy and refreshes if a new `toast` function is supplied after mount. The hook skips duplicate fetches on the initial render so a user provided at mount triggers only the React Query request.
-The React Query cache key uses `['dropdown', fetcher.name, user && user._id]` so the key is JSON serializable and predictable across renders.
+The React Query cache key uses `['dropdown', fetcherId, user && user._id]` where `fetcherId` is `fetcher.name || fetcher.toString()` so anonymous functions still generate a stable key.
 
 **Returns:** Object - `{items, isLoading, fetchData}`
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -235,8 +235,8 @@ function useAsyncAction(asyncFn, options) {
 function useDropdownData(fetcher, toastFn, user) {
   console.log(`useDropdownData is running with ${fetcher}`); // entry log for debugging
   if (!isFunction(fetcher)) { throw new Error('useDropdownData requires a function for `fetcher` parameter'); } // validate fetcher
-  // use fetcher.name so key is JSON serializable for React Query caching
-  const queryKey = useMemo(() => ['dropdown', fetcher.name, user && user._id], [fetcher.name, user && user._id]); // include user id so cache resets per user with function name
+  const fetcherId = fetcher.name || fetcher.toString(); // stable identifier ensures cache key uniqueness even for anonymous functions
+  const queryKey = useMemo(() => ['dropdown', fetcherId, user && user._id], [fetcher, fetcherId, user && user._id]); // include fetcher ref so cache updates when function changes
 
   const { data, isPending } = useQuery({ // query remote data via React Query
     queryKey, // unique cache key so data persists across mounts
@@ -265,7 +265,7 @@ function useDropdownData(fetcher, toastFn, user) {
 
     const userIdChanged = !!user && prevUserRef.current?._id !== user._id; // require user exists before checking id change
     const toastChanged = prevToastRef.current !== toastFn; // detect toast function swap for updates
-    if (userIdChanged || toastChanged) { fetchData().catch(() => {}); } // refetch when user id or toast fn changed
+    if (userIdChanged || toastChanged) { fetchData().catch(err => console.log(err)); } // log errors when refetch fails instead of silencing
 
     prevUserRef.current = user; // update last user for next render
     prevToastRef.current = toastFn; // update last toast for next render


### PR DESCRIPTION
## Summary
- create a stable `fetcherId` for dropdown queries
- log dropdown refetch errors
- document `fetcherId` usage in README

## Testing
- `npm test` *(fails: An update to TestComponent inside a test was not wrapped in act)*

------
https://chatgpt.com/codex/tasks/task_b_68507f51df80832293ff372b3eb64fb5