### PR TITLE
Fix dropdown cache removal key

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -270,7 +270,7 @@ function useDropdownData(fetcher, toastFn, user) {
     if (userIdChanged || toastChanged) { fetchData().catch(() => {}); } // refetch when user id or toast fn changed
 
     if (!user && prevUserRef.current) { // user logged out so clear cached data
-      const prevKey = ['dropdown', fetcher.name, prevUserRef.current._id]; // compute previous query key
+      const prevKey = ['dropdown', fetcherRef.current.id, prevUserRef.current._id]; // use id to match queryKey preventing stale cache with anonymous fetcher
       queryClient.removeQueries({ queryKey: prevKey }); // drop stale cache tied to old user
       queryClient.setQueryData(queryKey, []); // ensure items state resets to empty array
     }


### PR DESCRIPTION
## Summary
- ensure dropdown cache key removal uses stable fetcherRef id so anonymous fetchers clear stale data
- add inline comment explaining cache removal logic

## Testing
- `npm test` *(fails: Test suite incomplete due to act warnings)*
- `node test-simple.js` *(fails: apiRequest basic functionality: 500)*

------
https://chatgpt.com/codex/tasks/task_b_68508869f8708322822af406e6984cc2