### PR TITLE
Fix logout cache clearing

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -270,7 +270,7 @@ function useDropdownData(fetcher, toastFn, user) {
     if (userIdChanged || toastChanged) { fetchData().catch(() => {}); } // refetch when user id or toast fn changed
 
     if (!user && prevUserRef.current) { // user logged out so clear cached data
-      const prevKey = ['dropdown', fetcher.name, prevUserRef.current._id]; // compute previous query key
+      const prevKey = ['dropdown', stableId, prevUserRef.current._id]; // use stableId so anonymous fetchers remove correct cache
       queryClient.removeQueries({ queryKey: prevKey }); // drop stale cache tied to old user
       queryClient.setQueryData(queryKey, []); // ensure items state resets to empty array
     }


### PR DESCRIPTION
## Summary
- ensure useDropdownData uses stableId for previous key during logout cleanup
- expose queryClient in internal helpers test suite
- add regression test for anonymous fetcher cache clearing

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_b_6850880da87883229a642a2731ee3862