### PR TITLE
Fix apiRequest method normalization

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -174,9 +174,10 @@ function formatAxiosError(err) { // ensure all thrown errors are plain Error ins
  * @returns {Promise} Response data
 */
 async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
+  const normalizedMethod = method.toUpperCase(); // ensure method comparisons are case insensitive // changed
   try { // run request with offline fallback
-    const config = { url, method }; // base config used for all requests // changed
-    if (method === 'GET') { // treat GET differently so body isn't sent // added
+    const config = { url, method: normalizedMethod }; // base config uses normalized method // changed
+    if (normalizedMethod === 'GET') { // treat GET differently so body isn't sent // changed
       if (data !== null && data !== undefined) { // only attach params when data exists // added
         config.params = data; // map data to query params when provided // added
       }

--- a/test.js
+++ b/test.js
@@ -740,6 +740,13 @@ runTest('apiRequest with different HTTP methods and data', async () => {
   assertEqual(defaultResult.method, 'POST', 'Should default to POST method');
 });
 
+runTest('apiRequest accepts lowercase method', async () => { // verify case normalization
+  const lowerGet = await apiRequest('/api/test', 'get', { id: 3 });
+  assert(lowerGet.success === true, 'Should succeed with lowercase method');
+  assert(lowerGet.method === 'GET', 'Should normalize method to uppercase');
+  assert(lowerGet.requestParams.id === 3, 'Should send params correctly');
+});
+
 runTest('apiRequest error handling scenarios', async () => {
   // Test 500 error
   try {


### PR DESCRIPTION
## Summary
- normalize method to uppercase in `apiRequest`
- test lowercase method input

## Testing
- `npm test` *(fails: huge output, can't confirm)*

------
https://chatgpt.com/codex/tasks/task_b_6850887e758083228945ae940636b2db