### PR TITLE
fix toast timer cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const {
   useCallbackWithErrorHandling, // callback wrapper with errors // imported for completeness
   useAsyncAction, useDropdownData, createDropdownListHook, useDropdownToggle, // aggregate hook utilities // gathered here to ensure stable references across modules
   useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect, // UI-related helpers // centralizing UI hooks prevents scattered imports
-  showToast, toastSuccess, toastError, executeWithErrorToast, executeWithToastFeedback, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch // core API & toast utilities // exposes internal tools in one shot for clarity
+  showToast, toastSuccess, toastError, executeWithErrorToast, executeWithToastFeedback, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch, getToastTimeoutCount // core API & toast utilities // exposes internal tools in one shot for clarity
 } = require('./lib/hooks'); // CommonJS import keeps broad Node compatibility // require chosen so Node apps of any version can consume this module
 
 /**
@@ -73,6 +73,7 @@ module.exports = { // CommonJS export consolidating public API
   getToastListenerCount, // Allows tests to inspect active toast listeners // exported to help verify toast state
   resetToastSystem,      // Clears toast listeners between tests // public to reset global state in tests
   dispatch,              // Expose dispatch for advanced control and tests // exported so consumers can trigger custom actions
+  getToastTimeoutCount,  // Count pending toast timeouts // helps verify timers cleaned up
   
   // API and HTTP functionality
   apiRequest,            // Standardized HTTP request wrapper with error handling // public so external code uses shared axios logic

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -600,6 +600,7 @@ let memoryState = { toasts: [] }; // simple in-memory store for global toast sta
  */
 function dispatch(action) { // notify subscribers whenever toast state changes
   memoryState = reducer(memoryState, action); // apply update using reducer logic
+  if (action.type === "REMOVE_TOAST" && toastTimeouts.has(action.toastId)) { clearTimeout(toastTimeouts.get(action.toastId)); toastTimeouts.delete(action.toastId); } // clear timer so manual removal leaves no orphaned timeout
   listeners.forEach((listener) => {
     try { // isolate listener errors so others still run
       listener(memoryState); // publish new state to all listeners
@@ -706,6 +707,8 @@ function resetToastSystem() {
   console.log(`resetToastSystem has run resulting in a final value of ${JSON.stringify(memoryState)}`); // exit log
 }
 
+function getToastTimeoutCount() { console.log(`getToastTimeoutCount is running`); const result = toastTimeouts.size; console.log(`getToastTimeoutCount is returning ${result}`); return result; }
+
 /**
  * React hook that combines async actions with toast notifications
  * @param {Function} asyncFn - The async operation to run
@@ -796,5 +799,6 @@ module.exports = { // consolidated export for entire hooks library
   axiosClient,         // configured axios instance // exported so consumers share defaults
   getToastListenerCount, // test helper exposing listener set size // public for introspection
   resetToastSystem,     // reset listeners and state between tests // exported to clear global state
-  dispatch              // expose dispatch for tests to send custom actions // public for advanced usage
+  dispatch,             // expose dispatch for tests to send custom actions // public for advanced usage
+  getToastTimeoutCount  // expose internal timer count for tests // helps ensure cleanup
 };

--- a/test.js
+++ b/test.js
@@ -101,7 +101,7 @@ mockAxios.isAxiosError = (error) => error && error.isAxiosError === true; // mat
 const {
   useAsyncAction, useDropdownData, createDropdownListHook, useDropdownToggle,
   useEditForm, useIsMobile, useToast, toast, useToastAction, useAuthRedirect,
-  showToast, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch
+  showToast, stopEvent, apiRequest, getQueryFn, queryClient, formatAxiosError, axiosClient, getToastListenerCount, resetToastSystem, dispatch, getToastTimeoutCount
 } = require('./index.js'); // import library after axios stub so axiosClient can be overridden
 const { handle401Error, codexRequest, executeAxiosRequest } = require('./lib/api.js'); // internal API helpers without config helpers
 
@@ -953,6 +953,15 @@ runTest('dispatching unknown action leaves toast state unchanged', () => {
   TestRenderer.act(() => { dispatch({ type: 'UNKNOWN' }); });
   assertEqual(result.current.toasts.length, 1, 'State should remain after unknown action');
   unmount(); // remove listener
+});
+
+runTest('manual REMOVE_TOAST clears pending timer', () => {
+  resetToastSystem(); // ensure starting from empty state
+  const { id } = toast({ title: 'timer' }); // create toast to test timer
+  dispatch({ type: 'DISMISS_TOAST', toastId: id }); // schedule removal timer
+  assertEqual(getToastTimeoutCount(), 1, 'Timer should exist after dismiss');
+  dispatch({ type: 'REMOVE_TOAST', toastId: id }); // remove directly
+  assertEqual(getToastTimeoutCount(), 0, 'Timer should be cleared after remove');
 });
 
 runTest('executeWithErrorToast displays error toast', async () => {


### PR DESCRIPTION
## Summary
- clear timeout if toast removed directly
- expose timer count for tests
- verify timers cleaned when manually removing a toast

## Testing
- `npm test` *(fails: EPIPE errors)*

------
https://chatgpt.com/codex/tasks/task_b_6850886db4ec8322a1b060de7776dcb4