### PR TITLE
Normalize HTTP method in apiRequest

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -175,8 +175,9 @@ function formatAxiosError(err) { // ensure all thrown errors are plain Error ins
 */
 async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
   try { // run request with offline fallback
-    const config = { url, method }; // base config used for all requests // changed
-    if (method === 'GET') { // treat GET differently so body isn't sent // added
+    const httpMethod = method.toUpperCase(); // ensure case-insensitive methods work // added
+    const config = { url, method: httpMethod }; // store normalized method in config // modified
+    if (httpMethod === 'GET') { // treat GET differently so body isn't sent // modified
       if (data !== null && data !== undefined) { // only attach params when data exists // added
         config.params = data; // map data to query params when provided // added
       }

--- a/tests/internal-helpers.test.js
+++ b/tests/internal-helpers.test.js
@@ -7,8 +7,9 @@ module.exports = function helpersTests({ runTest, renderHook, assert, assertEqua
     useAsyncStateWithCallbacks,
     useCallbackWithErrorHandling,
     executeWithLoadingState,
-    useDropdownData
-  } = require('../lib/hooks.js'); // import functions under test
+    useDropdownData,
+    apiRequest
+  } = require('../lib/hooks.js'); // import functions under test and apiRequest for HTTP checks // modified
   const { executeWithErrorHandling, executeSyncWithErrorHandling } = require('../lib/errorHandling.js'); // error helpers for tests
 
   runTest('executeWithLoadingState resolves and toggles loading', async () => {
@@ -168,6 +169,13 @@ module.exports = function helpersTests({ runTest, renderHook, assert, assertEqua
     } catch (e) {
       assertEqual(e.message, 'undefined', 'Undefined becomes error with message');
     }
+  });
+
+  runTest('apiRequest GET lowercase method attaches query params', async () => {
+    const res = await apiRequest('/x', 'get', { id: 1 }); // call with lowercase method to verify normalization // added
+    assert(res.success === true, 'Request should succeed'); // confirm mock success // added
+    assert(res.requestParams.id === 1, 'Should send data as query params'); // confirm params usage // added
+    assert(res.requestData === undefined, 'Should not send body for GET'); // ensure body omitted // added
   });
 };
 


### PR DESCRIPTION
## Summary
- normalize method argument in `apiRequest` to uppercase
- test that lowercase GET attaches data as query params

## Testing
- `npm test` *(fails: output truncated but shows passing tests)*

------
https://chatgpt.com/codex/tasks/task_b_68508811396c8322a2105805cced59f0