### PR TITLE
Suppress act warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ npm test
 ```
 
 The `test-setup` script falls back to local stubs when `qtests` is not available.
-React may display "act()" warnings during `npm test`; these warnings are expected and can be safely ignored.
+React may display "act()" warnings during `npm test`; the test runner now wraps `console.error` to filter these messages so output stays readable.
 
 If `qtests` is missing, install it explicitly:
 

--- a/test.js
+++ b/test.js
@@ -26,6 +26,12 @@ const React = require('react'); // Load real React for hook rendering //(replace
 const TestRenderer = require('react-test-renderer'); // Renderer for executing hooks //(provide test renderer for hook execution)
 globalThis.IS_REACT_ACT_ENVIRONMENT = true; // flag React act environment for warnings so TestRenderer.act works correctly
 
+const originalConsoleError = console.error; // store original error logger so we can forward non-act messages
+console.error = (msg, ...args) => { // override to filter noisy React act warnings while preserving others
+  if (typeof msg === 'string' && msg.includes('act(')) return; // skip act warnings for clarity in test output
+  return originalConsoleError.call(console, msg, ...args); // forward any other error messages to original logger
+};
+
 /**
  * Render a hook via react-test-renderer to keep tests lightweight.
  *


### PR DESCRIPTION
## Summary
- wrap `console.error` in test.js to filter out React `act()` warnings
- note error suppression in the README testing docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850a26f71d48322a3ad84f347a1c66f