### PR TITLE
Move query client comment

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -233,6 +233,8 @@ function getQueryFn(options = { on401: 'throw' }) { // default rejects on 401 so
       throw formatAxiosError(err); // rethrow normalized error so calling code can handle consistently
     }
   }; //(end returned QueryFunction)
+} //(end getQueryFn)
+
 /**
  * Shared React Query client with conservative defaults.
  *
@@ -242,7 +244,6 @@ function getQueryFn(options = { on401: 'throw' }) { // default rejects on 401 so
  * avoid unexpected network traffic. Applications may override these
  * settings if they require different caching behavior.
  */
-} //(end getQueryFn)
 
 const queryClient = new QueryClient({ // single client ensures caching behavior matches across hooks
   defaultOptions: {


### PR DESCRIPTION
## Summary
- move shared query client comment block to sit just above the query client constant
- keep `//(end getQueryFn)` immediately after the function closing brace

## Testing
- `npm test` *(fails: process ended early)*

------
https://chatgpt.com/codex/tasks/task_b_6850a5a7a8cc8322bfd0eae5ff509d89