### PR TITLE
Clarify custom test helpers

### DIFF
--- a/test-clean.js
+++ b/test-clean.js
@@ -43,7 +43,7 @@ global.window = {
 
 let testResults = []; // collected sequentially to keep output order stable
 
-function test(name, fn) { // run test sequentially to keep state isolated
+function test(name, fn) { // simple runner keeps order deterministic and avoids Jest overhead
   try {
     // Silence console during test execution
     console.log = () => {};
@@ -68,11 +68,11 @@ function test(name, fn) { // run test sequentially to keep state isolated
   }
 }
 
-function assert(condition, message) { // throw if condition evaluates to false
+function assert(condition, message) { // minimal assertion to stop on first failure and keep queue simple
   if (!condition) throw new Error(message || 'Assertion failed');
 }
 
-function renderHook(hookFn) { // run hook with react-test-renderer for assertions
+function renderHook(hookFn) { // lightweight hook runner, TestRenderer avoids DOM and complex frameworks
   let value;
   function TestComponent() {
     value = hookFn();

--- a/test-comprehensive.js
+++ b/test-comprehensive.js
@@ -49,7 +49,7 @@ function suite(name, tests) { // collect tests under a named suite for organized
   testSuites.push({ name, tests });
 }
 
-function test(name, fn) { // run test sequentially to avoid shared state issues
+function test(name, fn) { // simple sequential runner keeps suites deterministic without Jest
   try {
     console.log = console.error = console.warn = () => {};
     fn();
@@ -65,17 +65,17 @@ function test(name, fn) { // run test sequentially to avoid shared state issues
   }
 }
 
-function assert(condition, message) { // throw if condition evaluates to false
+function assert(condition, message) { // minimal assertion helper ensures failures stop subsequent tests
   if (!condition) throw new Error(message || 'Assertion failed');
 }
 
-function assertEqual(actual, expected, message) { // throw when values do not match
+function assertEqual(actual, expected, message) { // equality helper used instead of assertion libs
   if (actual !== expected) {
     throw new Error(`${message}: expected ${expected}, got ${actual}`);
   }
 }
 
-function renderHook(hookFn) { // execute hook with react-test-renderer and return value
+function renderHook(hookFn) { // lightweight hook runner; TestRenderer removes need for a DOM or Jest
   let value;
   function TestComponent() {
     value = hookFn();

--- a/test-core.js
+++ b/test-core.js
@@ -32,7 +32,7 @@ console.log = () => {};
 let passed = 0;
 let total = 0;
 
-function test(name, fn) { // lightweight runner executing tests sequentially
+function test(name, fn) { // sequential runner keeps order deterministic without Jest
   total++;
   try {
     fn();
@@ -46,11 +46,11 @@ function test(name, fn) { // lightweight runner executing tests sequentially
   }
 }
 
-function assert(condition, message) { // throw if condition is false
+function assert(condition, message) { // minimal assertion halts suite on failure for reliability
   if (!condition) throw new Error(message || 'Assertion failed');
 }
 
-function renderHook(hookFn) { // execute a hook and expose its return value for assertions
+function renderHook(hookFn) { // executes hook with TestRenderer; no DOM required and effects flush synchronously
   let value;
   function TestComponent() {
     value = hookFn();

--- a/test-final.js
+++ b/test-final.js
@@ -70,17 +70,17 @@ console.log = () => {};
 let testCount = 0; // running tally of executed tests
 let passedTests = 0; // count of successful tests
 
-function assert(condition, message) { // throw when condition fails
+function assert(condition, message) { // minimal assertion to keep runner dependency free
   if (!condition) throw new Error(message || 'Assertion failed');
 }
 
-function assertEqual(actual, expected, message) { // compare expected and actual values
+function assertEqual(actual, expected, message) { // equality check without external assertion libraries
   if (actual !== expected) {
     throw new Error(`${message}: expected ${expected}, got ${actual}`);
   }
 }
 
-function runTest(name, testFn) { // run queued test and track pass/fail status
+function runTest(name, testFn) { // queued execution prevents race conditions without using Jest
   testCount++;
   try {
     const result = testFn();
@@ -102,7 +102,7 @@ function runTest(name, testFn) { // run queued test and track pass/fail status
   }
 }
 
-function renderHook(hookFn) { // execute hook with react-test-renderer and expose value
+function renderHook(hookFn) { // minimal hook execution using TestRenderer for deterministic output
   let value;
   function TestComponent() {
     value = hookFn();

--- a/test-focused.js
+++ b/test-focused.js
@@ -51,7 +51,7 @@ let tests = [];
 let passed = 0;
 let failed = 0;
 
-function test(name, fn) {
+function test(name, fn) { // sequential runner keeps single-threaded order instead of using Jest
   try {
     silenceConsole();
     fn();
@@ -65,11 +65,11 @@ function test(name, fn) {
   }
 }
 
-function assert(condition, message) {
+function assert(condition, message) { // simple assertion helper to keep environment minimal
   if (!condition) throw new Error(message || 'Assertion failed');
 }
 
-function renderHook(hookFn) {
+function renderHook(hookFn) { // run hook via TestRenderer so updates flush immediately without DOM
   let value;
   function TestComponent() {
     value = hookFn();

--- a/test-production.js
+++ b/test-production.js
@@ -27,7 +27,7 @@ global.window = {
 let passed = 0;
 let total = 0;
 
-function test(name, fn) { // run a single test sequentially so shared state stays consistent
+function test(name, fn) { // sequential runner keeps order deterministic without needing Jest
   total++;
   try {
     fn();
@@ -39,11 +39,11 @@ function test(name, fn) { // run a single test sequentially so shared state stay
   }
 }
 
-function assert(condition, message) { // throw when condition is false
+function assert(condition, message) { // small assertion helper keeps test environment simple
   if (!condition) throw new Error(message || 'Assertion failed');
 }
 
-function renderHook(hookFn) { // run hook with react-test-renderer and return current value
+function renderHook(hookFn) { // minimal hook runner; TestRenderer avoids DOM and flushes effects synchronously
   let value;
   function TestComponent() {
     value = hookFn();

--- a/test-silent.js
+++ b/test-silent.js
@@ -38,17 +38,17 @@ let passedTests = 0;
 let failedTests = 0;
 let testResults = [];
 
-function assert(condition, message) {
+function assert(condition, message) { // basic assertion keeps suite independent of assertion libraries
   if (!condition) throw new Error(message || 'Assertion failed');
 }
 
-function assertEqual(actual, expected, message) {
+function assertEqual(actual, expected, message) { // equality helper for clarity
   if (actual !== expected) {
     throw new Error(`${message}: expected ${expected}, got ${actual}`);
   }
 }
 
-function renderHook(hookFn) {
+function renderHook(hookFn) { // lightweight hook runner; TestRenderer avoids DOM so tests stay fast
   let value;
   function TestComponent() {
     value = hookFn();
@@ -68,7 +68,7 @@ function renderHook(hookFn) {
 }
 
 // Test execution with clean output
-function runTest(name, testFn) {
+function runTest(name, testFn) { // sequential execution and manual logging mimic Jest's behavior without the dependency
   testCount++;
   const testStart = Date.now();
   

--- a/test-simple.js
+++ b/test-simple.js
@@ -25,7 +25,7 @@ let passedTests = 0; // incremented for every successful test
 let failedTests = 0; // incremented whenever a test throws
 let testResults = []; // collects summary data for post-run report
 
-function assert(condition, message) { // throw if condition is false
+function assert(condition, message) { // tiny assertion helper keeps runner lightweight and deterministic
   if (!condition) {
     throw new Error(message || 'Assertion failed');
   }
@@ -37,7 +37,7 @@ function assertEqual(actual, expected, message) { // compare actual and expected
   }
 }
 
-function runTest(name, testFn) { // run a single test and record result sequentially
+function runTest(name, testFn) { // sequential execution avoids needing Jest and prevents test races
   testCount++;
   const startTime = Date.now();
   
@@ -69,14 +69,14 @@ function runTest(name, testFn) { // run a single test and record result sequenti
   }
 }
 
-function renderHook(hookFn) { // run hook with react-test-renderer and return its value
+function renderHook(hookFn) { // minimal hook runner; TestRenderer + act keeps state updates synchronous
   let value;
   function TestComponent() {
     value = hookFn();
     return null;
   }
-  TestRenderer.act(() => { // run hook without a real DOM
-    TestRenderer.create(React.createElement(TestComponent)); // keeps dependencies small
+  TestRenderer.act(() => { // use act so effects flush immediately
+    TestRenderer.create(React.createElement(TestComponent)); // avoids DOM and heavy frameworks like Jest
   });
   return { result: { current: value } };
 }


### PR DESCRIPTION
## Summary
- expand comments for `runTest`, `assert` and `renderHook` across test runners
- explain why the simple queue avoids race conditions and why no Jest is used

## Testing
- `npm test` *(fails: react-test-renderer deprecation messages only)*

------
https://chatgpt.com/codex/tasks/task_b_6850a58f65f88322aa8e3c94fe6d05ed