### PR TITLE
Clarify toast helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,22 +199,27 @@ Runs an async operation and displays a success toast when it resolves or an erro
 Combined preventDefault and stopPropagation utility for React events.
 
 ### getToastListenerCount()
-Returns the current number of registered toast listeners. Useful for tests verifying cleanup.
+Returns the current number of registered toast listeners. Exposed solely so tests
+can confirm components clean up subscriptions and avoid memory leaks.
 
 **Returns:** number - Current count of active toast listeners
 
 ### resetToastSystem()
-Clears all toast listeners, cancels pending removal timers, and resets toast state. Useful for isolated testing environments.
+Clears all toast listeners, cancels pending removal timers, and resets toast state. Provided for tests to start from a known baseline without leftover toasts.
 
 **Returns:** void
 
 ### dispatch(action)
-Centralized dispatch function used by the toast system to update global toast state and notify listeners.
+Centralized dispatch function used by the toast system to update global toast state and notify listeners. Each listener is called inside a try/catch so one failing component does not block others.
 
 **Parameters:**
 - `action` (Object): Toast action with `type`, `toast`, or `toastId` fields
 
 **Returns:** void
+
+### getToastTimeoutCount()
+Returns the number of pending toast removal timeouts. This diagnostic helper is
+used in tests to ensure dismissals clear timers and prevent memory leaks.
 
 ## Validation Utilities
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -586,15 +586,18 @@ const reducer = (state, action) => { // state machine controlling toast lifecycl
   }
 }; // pure function so state updates remain predictable
 
-const listeners = new Set(); // components subscribe here to receive toast state updates without duplicates
-let memoryState = { toasts: [] }; // simple in-memory store for global toast state
+const listeners = new Set(); // Set avoids duplicate callbacks and makes delete O(1) so unmounted components free memory quickly
+let memoryState = { toasts: [] }; // Object wrapper keeps state resettable between tests avoiding lingering references
 
 /**
  * Dispatch actions to the toast store and update subscribers
  *
  * The reducer ensures state transitions are predictable and easy to trace.
- * All listeners are called after each action so components using useToast
- * stay in sync with the latest toast list.
+ * After state is updated, every registered listener is invoked sequentially
+ * with the new state so subscribed components stay synchronized. Listener
+ * callbacks run inside a try/catch block so one misbehaving subscriber
+ * cannot interrupt notifications to the rest. Errors are logged then
+ * swallowed to preserve global toast functionality.
  *
  * @param {{type:string, toast?:Object, toastId?:string}} action - Toast action descriptor
  */
@@ -681,9 +684,10 @@ function useToast() {
 /**
  * Provide the number of active toast listeners for diagnostics
  *
- * Mainly used in tests to confirm components register/unregister
- * correctly. The Set above prevents duplicates so this count mirrors
- * actual subscriptions.
+ * Exposed primarily for the test suite to verify that components add
+ * and remove subscriptions correctly. Returning this value allows
+ * tests to assert that no orphan listeners remain, protecting against
+ * memory leaks in long-running sessions.
  */
 function getToastListenerCount() {
   console.log(`getToastListenerCount is running`); // entry log
@@ -695,8 +699,10 @@ function getToastListenerCount() {
 /**
  * Reset toast infrastructure between tests
  *
- * Clears listeners, timers, and in-memory state so each test starts
- * from a known baseline. Centralizing this cleanup avoids repetition.
+ * Provided for testing environments to guarantee that one test's toasts
+ * do not bleed into the next. By clearing listeners and timers we avoid
+ * dangling references which could otherwise accumulate across multiple
+ * test runs.
  */
 function resetToastSystem() {
   console.log(`resetToastSystem is running`); // entry log
@@ -707,6 +713,8 @@ function resetToastSystem() {
   console.log(`resetToastSystem has run resulting in a final value of ${JSON.stringify(memoryState)}`); // exit log
 }
 
+// Expose the number of active toast removal timers so tests can ensure
+// that dismissals properly clear timeouts and no leaks occur over time.
 function getToastTimeoutCount() { console.log(`getToastTimeoutCount is running`); const result = toastTimeouts.size; console.log(`getToastTimeoutCount is returning ${result}`); return result; }
 
 /**


### PR DESCRIPTION
## Summary
- explain rationale for using Set and object for toast state
- document dispatch listener handling and error swallowing
- expand README docs on toast diagnostics helpers

## Testing
- `npm test` *(fails: react-test-renderer warning; log truncated)*

------
https://chatgpt.com/codex/tasks/task_b_6850a57a1bc88322b3c35136b942bd46