### PR TITLE
Improve API docs

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -83,8 +83,11 @@ function handle401Error(error, behavior) { // convert 401 into null when allowed
  * Wrapper for axios requests with consistent error handling and logging
  *
  * This helper centralizes the try/catch pattern for axios so apiRequest and
- * getQueryFn do not duplicate the same logic. It also routes every request
- * through codexRequest so offline mocks can be used during development.
+ * getQueryFn do not duplicate the same logic. Every request first passes through
+ * `codexRequest`, which means the call can transparently return mock data when
+ * `OFFLINE_MODE` is enabled. 401 handling is configurable because some requests
+ * are optional while others require authentication. By letting the caller choose
+ * `'returnNull'` or `'throw'` we support both flows without duplicating code.
  *
  * @param {Function} axiosCall - The axios request function to execute
  * @param {string} unauthorizedBehavior - How to handle 401 errors
@@ -106,12 +109,11 @@ async function executeAxiosRequest(axiosCall, unauthorizedBehavior, mockResponse
 /**
  * Codex request wrapper for development/offline mode support
  *
- * This helper allows frontend work to continue even when the backend
- * API is unavailable. When OFFLINE_MODE is set, the provided mock
- * response is returned so components can render predictable data.
- * In normal operation the request function is executed directly.
- * This infrastructure also logs responses making it easier to debug
- * future extensions like recording and replaying calls.
+ * This helper lets the library intercept axios calls so that offline or mock
+ * data can be provided without changing calling code. When `OFFLINE_MODE` is
+ * enabled the given mock response (or a default one) is returned, otherwise the
+ * `requestFn` executes normally. The response is always shaped like a real axios
+ * result so React Query and other consumers remain unaware that a mock was used.
  *
  * @param {Function} requestFn - The actual request function to execute
  * @param {Object} mockResponse - Mock response to return in offline mode
@@ -200,10 +202,12 @@ async function apiRequest(url, method = 'POST', data) { //(public axios wrapper)
 /**
  * Create a React Query function that handles 401 errors gracefully
  *
- * The default behavior is to throw on 401 so protected queries fail
- * fast. Passing on401:'returnNull' makes the query resolve to null
- * instead, which is helpful for optional data that should not block
- * page rendering.
+ * This factory ties axios requests into React Query's `useQuery` mechanism. It
+ * uses `codexRequest` under the hood so offline mode works the same as normal
+ * network calls. The 401 behavior is configurable because some queries are
+ * optional (missing data is acceptable) while others must surface an error. By
+ * allowing `'returnNull'` or `'throw'` the same query wrapper can serve both
+ * scenarios.
  *
  * @param {Object} options - Configuration options
  * @param {string} options.on401 - How to handle 401 errors ('returnNull' or 'throw')
@@ -240,7 +244,9 @@ function getQueryFn(options = { on401: 'throw' }) { // default rejects on 401 so
  * surface immediately so calling code can decide how to recover.
  * Data never becomes stale and refetching on window focus is disabled to
  * avoid unexpected network traffic. Applications may override these
- * settings if they require different caching behavior.
+ * settings if they require different caching behavior. The client uses
+ * `getQueryFn` by default so every query benefits from `codexRequest`
+ * offline support and configurable 401 handling.
  */
 } //(end getQueryFn)
 


### PR DESCRIPTION
## Summary
- clarify offline mock flow in `codexRequest`
- explain how `executeAxiosRequest` wraps axios and handles 401s
- update `getQueryFn` docs about offline/401 configuration
- document React Query client linkage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850a58856148322a326318536207e89