### PR TITLE
Modify toast timer getter comment

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -719,7 +719,12 @@ function resetToastSystem() {
 
 // Expose the number of active toast removal timers so tests can ensure
 // that dismissals properly clear timeouts and no leaks occur over time.
-function getToastTimeoutCount() { console.log(`getToastTimeoutCount is running`); const result = toastTimeouts.size; console.log(`getToastTimeoutCount is returning ${result}`); return result; }
+function getToastTimeoutCount() {
+  console.log(`getToastTimeoutCount is running`); // entry log
+  const result = toastTimeouts.size; // number of active removal timers
+  console.log(`getToastTimeoutCount is returning ${result}`); // exit log
+  return result; // count used by tests to verify toast timeouts are cleared
+}
 
 /**
  * React hook that combines async actions with toast notifications


### PR DESCRIPTION
## Summary
- expand `getToastTimeoutCount` function to match style
- document return usage for tests

## Testing
- `npm test` *(fails to complete: `react-test-renderer` warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6850a8fca2f8832289296098dd18bd19