### PR TITLE
Improve error transform docs

### DIFF
--- a/lib/errorHandling.js
+++ b/lib/errorHandling.js
@@ -14,7 +14,9 @@
  * returns a Promise. Wrapping the call keeps each module's code short while
  * ensuring every async path logs and rethrows errors the same way.
  * Error transforms allow callers to wrap or augment errors before they
- * propagate. This async wrapper exists alongside the synchronous version so
+ * propagate. When a transform returns a Promise we await it so callers can
+ * perform async side effects like reporting or localization before the error
+ * continues. This async wrapper exists alongside the synchronous version so
  * modules can keep their functions simple without always converting to async.
  * Typical usage: wrap API calls or database writes so unexpected errors surface consistently.
  *
@@ -33,14 +35,14 @@ async function executeWithErrorHandling(fn, functionName, errorTransform) {
     if (errorTransform && typeof errorTransform === 'function') { // caller supplied mapper
       let transformed = errorTransform(error); // map original error to new one
       if (transformed && typeof transformed.then === 'function') { // mapper returned promise
-        transformed = await transformed; // await promise so we examine the real value
+        transformed = await transformed; // wait so async logging or decoration completes before rethrow
       }
       if (!transformed || !(transformed instanceof Error)) { // wrap non Error values
         transformed = new Error(String(transformed)); // ensure consistent Error type
       }
-      throw transformed; // rethrow mapped error immediately
+      throw transformed; // rethrow mapped error so caller still handles failure
     }
-    throw error; // no mapper -> rethrow original error
+    throw error; // no mapper -> preserve original error for upstream handling
   }
 }
 
@@ -50,7 +52,8 @@ async function executeWithErrorHandling(fn, functionName, errorTransform) {
  * This wrapper previously avoided async/await but now supports async transforms
  * while still executing the provided function synchronously. The wrapper remains
  * useful for simple utilities yet can await an async error transform when
- * provided. Typical usage: wrap simple data transformations that could throw
+ * provided, allowing tasks like logging to complete before the error is sent
+ * upward. Typical usage: wrap simple data transformations that could throw
  * synchronously but require standardized error mapping.
  *
  * @param {Function} fn - Synchronous function to execute
@@ -68,14 +71,14 @@ async function executeSyncWithErrorHandling(fn, functionName, errorTransform) {
     if (errorTransform && typeof errorTransform === 'function') { // custom mapper exists
       let transformed = errorTransform(error); // run mapper on error
       if (transformed && typeof transformed.then === 'function') { // guard for promises
-        transformed = await transformed; // wait if async to keep behavior consistent
+        transformed = await transformed; // wait so async side effects finish before proceeding
       }
       if (!transformed || !(transformed instanceof Error)) { // ensure Error instance
         transformed = new Error(String(transformed)); // normalize falsy or non Error values
       }
-      throw transformed; // rethrow normalized error
+      throw transformed; // propagate transformed error so outer layers can react
     }
-    throw error; // otherwise rethrow original
+    throw error; // otherwise rethrow original to maintain stack trace
   }
 }
 


### PR DESCRIPTION
## Summary
- clarify why executeWithErrorHandling awaits transform results
- clarify why executeSyncWithErrorHandling can await and rethrow

## Testing
- `npm test` *(fails: ENOVERS)*

------
https://chatgpt.com/codex/tasks/task_b_6850a912c1d4832289b42633abd22457