### PR TITLE
Add inline summaries for exported utilities

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,7 +32,7 @@ const { safeStringify } = require('./validation.js'); // import safe-json-string
  * The entry log records the wrapped operation's source to provide context on the
  * function being executed, rather than repeating the operation name.
  */
-async function executeAsyncWithLogging(operation, operationName, errorHandler) { // wrapper for async ops with unified logs
+async function executeAsyncWithLogging(operation, operationName, errorHandler) { // unify async pattern and centralize logging to reduce repetitive try/catch
   console.log(`executeAsyncWithLogging is running with ${operationName}`); // trace parameters for debugging
   // include stringified operation so logs reveal the actual function being executed
   logFunction(operationName, 'entry', operation && operation.toString ? operation.toString() : 'operation function'); // record the wrapped function for debugging
@@ -87,7 +87,7 @@ async function executeAsyncWithLogging(operation, operationName, errorHandler) {
  * @returns {Object} Toast result object with dismiss/update methods
  * @throws {Error} Re-throws any errors from the toast function for proper error handling
  */
-const showToast = withToastLogging('showToast', function(toast, message, title, variant) { // create and log toast
+const showToast = withToastLogging('showToast', function(toast, message, title, variant) { // central toast wrapper keeps format consistent across UI libraries
   console.log(`showToast is running with ${message}`); // log message parameter for tracing
   if (typeof toast !== 'function') { throw new Error('showToast requires a function for `toast` parameter'); } // fail fast when dependency injection missing
   const res = toast({ title: title, description: message, variant: variant }); // call injected toast with normalized object so UI library agnostic
@@ -123,7 +123,7 @@ const showToast = withToastLogging('showToast', function(toast, message, title, 
  * @returns {Object} Toast result object for programmatic control if needed
  * @throws {Error} Re-throws any underlying toast errors to preserve error chain
  */
-function toastError(toast, message, title = `Error`) { // wrapper around showToast for errors
+function toastError(toast, message, title = `Error`) { // standard error toast to enforce uniform style and wording
   console.log(`toastError is running with ${message}`); // trace parameters for debugging
   try { // show the error toast and capture any issues
     // Use destructive variant to ensure error messages have appropriate visual treatment
@@ -164,7 +164,7 @@ function toastError(toast, message, title = `Error`) { // wrapper around showToa
  * @returns {Object} Toast result object for programmatic control if needed
  * @throws {Error} Re-throws any underlying toast errors to preserve error chain
  */
-function toastSuccess(toast, message, title = `Success`) { // wrapper for success messages
+function toastSuccess(toast, message, title = `Success`) { // standard success toast for consistent positive feedback
   console.log(`toastSuccess is running with ${message}`); // trace parameters for debugging
   try { // attempt toast creation
     // Use default variant for positive but not overwhelming visual feedback
@@ -210,7 +210,7 @@ function toastSuccess(toast, message, title = `Success`) { // wrapper for succes
  * @param {Event|SyntheticEvent} e - DOM or React synthetic event object to stop
  * @throws {Error} Re-throws any errors to preserve debugging information
  */
-function stopEvent(e) { // cancel browser event reliably
+function stopEvent(e) { // prevent default and bubbling to simplify event handlers
   if (!e || typeof e.preventDefault !== 'function' || typeof e.stopPropagation !== 'function') { throw new Error('Invalid event object'); } // ensure event object has required methods for consistent behaviour
   console.log(`stopEvent is running with ${e.type}`); // trace event type to debug unexpected interactions after validation
   try { // attempt to cancel event
@@ -238,7 +238,7 @@ function stopEvent(e) { // cancel browser event reliably
  * @param {string} phase - Phase of execution ('entry', 'exit', 'error')
  * @param {*} data - Data to log (parameters, return values, errors)
  */
-function logFunction(functionName, phase, data) { // unified logging helper
+function logFunction(functionName, phase, data) { // consistent console format aids debugging across modules
   if (process.env.NODE_ENV === 'production') { return; } // skip logging in prod for cleaner output
   console.log(`logFunction is running with ${functionName},${phase}`); // trace parameters for debugging
   switch (phase) { // branch on execution phase for clarity
@@ -283,7 +283,7 @@ function logFunction(functionName, phase, data) { // unified logging helper
  * @param {Function} operation - The core operation to execute
  * @returns {Function} Wrapped function with logging and error handling
  */
-function withToastLogging(functionName, operation) { // wraps toast functions with logs; introduces one stack frame yet removes per-call try/catch
+function withToastLogging(functionName, operation) { // higher-order wrapper centralizes toast logging logic
   console.log(`withToastLogging is running with ${functionName}`); // trace wrapper creation
   const wrapped = function(...args) { // return a new function preserving API
     logFunction(functionName, 'entry', args[1] || 'params'); // start log for easier tracing
@@ -333,19 +333,19 @@ function withToastLogging(functionName, operation) { // wraps toast functions wi
  */
 module.exports = { // expose utilities via CommonJS for compatibility
   // Async execution utilities for consistent error handling
-  executeAsyncWithLogging,  // Standardized async operation wrapper // public to share one async logging pattern
+  executeAsyncWithLogging,  // central async wrapper so all modules share consistent logging
 
   // Logging utilities for consistent debugging
-  logFunction,        // Standardized function logging utility // exported so external code can match library logs
-  withToastLogging,   // expose wrapper so tests can verify logging wrapper behaviour // public for advanced debugging
+  logFunction,        // logging helper ensures uniform console output across project
+  withToastLogging,   // HOF adds consistent try/catch and logging around toast helpers
   
   // Toast notification utilities for consistent user feedback
-  showToast,      // Primary toast function with full customization options // exported so any module can show a toast
-  toastSuccess,   // Specialized success message display // public convenience for success cases
-  toastError,     // Specialized error message display // exported for uniform error toasts
+  showToast,      // basic toast creator to abstract UI library details
+  toastSuccess,   // success toast helper to encourage standardized positive feedback
+  toastError,     // error toast helper so all errors use destructive styling
   
   // Event handling utilities for common DOM interactions
-  stopEvent       // Combined preventDefault + stopPropagation for cleaner code // public DOM helper shared across components
+  stopEvent       // one call prevents default and bubbles so handlers stay concise
 
 }; // end of utility exports
 // Exports are grouped so consumers can import only the utilities they need: async helpers, logging tools, toast wrappers, and DOM helpers.


### PR DESCRIPTION
## Summary
- clarify inline comments in `lib/utils.js`

## Testing
- `npm test` *(fails: couldn't complete test suite)*

------
https://chatgpt.com/codex/tasks/task_b_6850a90e87108322927435d5deaf27ee