### PR TITLE
Add toast separation rationale comments

### DIFF
--- a/lib/toastIntegration.js
+++ b/lib/toastIntegration.js
@@ -26,6 +26,7 @@ const { showToast } = require('./utils'); // core toast utilities
  * @param {string} errorTitle - Title for error toast
  * @returns {*} Operation result or throws error
  */
+// Rationale: separating helpers lets callers opt-in to success toasts while always reporting errors
 async function executeWithErrorToast(operation, toast, errorTitle = 'Error') { // display error toast on failure
   try {
 
@@ -57,6 +58,7 @@ async function executeWithErrorToast(operation, toast, errorTitle = 'Error') { /
  * @param {string} errorTitle - Title for error toast
  * @returns {*} Operation result or throws error
  */
+// Rationale: success toasts are optional; this helper covers flows needing explicit success feedback while the error-only version keeps other flows quiet
 async function executeWithToastFeedback(operation, toast, successMessage, errorTitle = 'Error') { // show success or error toast
   try {
 
@@ -80,8 +82,7 @@ async function executeWithToastFeedback(operation, toast, successMessage, errorT
 }
 
 module.exports = { // expose toast helpers for reuse
-  executeWithErrorToast,   // utility for operations that may fail // exported so any async function can show error toasts
-  executeWithToastFeedback // success/error toast helper // public to provide consistent toast flow
-
+  executeWithErrorToast,   // export error-only helper so success feedback is opt-in
+  executeWithToastFeedback // export success+error helper when success confirmation is needed
 }; // end toast integration exports
 


### PR DESCRIPTION
## Summary
- document why toast helpers are split in `toastIntegration`

## Testing
- `npm test` *(fails to finish due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_b_6850a916d1b08322a0718b22ff68e0e4