### PR TITLE
Add rationale comments

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -297,6 +297,10 @@ function useDropdownData(fetcher, toastFn, user) {
  * Example usage:
  *   const useUsersList = createDropdownListHook(() => apiRequest('/api/users', 'GET'));
  *   // Now useUsersList can be used like any other hook
+ *
+ * We close over the fetcher in the returned hook so consumers never have
+ * to include it in dependency arrays, keeping callback references stable
+ * and preventing unnecessary re-renders.
  * 
  * This pattern is particularly useful when you have multiple components that need
  * the same data but you want to avoid prop drilling or context complexity.
@@ -441,7 +445,9 @@ const MOBILE_BREAKPOINT = 768; // 768px chosen to match common tablet breakpoint
  *
  * The react-responsive library simplifies media queries and handles
  * server-side rendering edge cases. We rely on its implementation to
- * manage event listeners and state internally.
+ * manage event listeners and state internally. Using it keeps this hook
+ * dependency-free from custom matchMedia logic while providing stable
+ * results during SSR and client hydration.
  *
  * @returns {boolean} True if the viewport is narrower than the breakpoint
  */
@@ -619,11 +625,9 @@ function dispatch(action) { // notify subscribers whenever toast state changes
 
 /**
  * Create a new toast in the global store
- *
-
  * Each toast receives a unique id from nanoid() so updates and dismisses
-
- * can target the specific toast later. The function dispatches an ADD_TOAST
+ * can target the specific toast later. Using nanoid avoids a global counter
+ * so parallel test runs never collide. The function dispatches an ADD_TOAST
  * action and exposes helpers for modification.
  *
  * @param {Object} props - Initial toast values
@@ -663,6 +667,9 @@ function toast(props) {
 
 /**
  * React hook for managing toast notifications
+ *
+ * Listeners are stored in a Set so each component registers at most once,
+ * guaranteeing stable callback references and preventing duplicate updates.
  * @returns {Object} Returns toast state and helper functions
  */
 function useToast() {
@@ -696,6 +703,8 @@ function useToast() {
 function getToastListenerCount() {
   console.log(`getToastListenerCount is running`); // entry log
   const result = listeners.size; // count of subscribed components
+  // using Set.size here reflects stable listener references; if a listener leaks
+  // the count reveals it immediately in tests, preventing memory growth
   console.log(`getToastListenerCount is returning ${result}`); // exit log
   return result; // expose listener count for testing purposes
 }
@@ -713,13 +722,18 @@ function resetToastSystem() {
   listeners.clear(); // remove all listeners for isolated tests
   memoryState = { toasts: [] }; // reset toast state
   toastTimeouts.forEach((timeout) => clearTimeout(timeout)); // cancel pending removals so no stray timers fire
-  toastTimeouts.clear(); // drop handles to fully reset map
+  toastTimeouts.clear(); // drop handles to fully reset map so tests start fresh and no stale timers remain
   console.log(`resetToastSystem has run resulting in a final value of ${JSON.stringify(memoryState)}`); // exit log
 }
 
 // Expose the number of active toast removal timers so tests can ensure
 // that dismissals properly clear timeouts and no leaks occur over time.
-function getToastTimeoutCount() { console.log(`getToastTimeoutCount is running`); const result = toastTimeouts.size; console.log(`getToastTimeoutCount is returning ${result}`); return result; }
+function getToastTimeoutCount() {
+  console.log(`getToastTimeoutCount is running`); // entry log
+  const result = toastTimeouts.size; // number of scheduled removals indicates cleanup health
+  console.log(`getToastTimeoutCount is returning ${result}`); // exit log
+  return result; // expose timeout count so tests detect lingering timers
+}
 
 /**
  * React hook that combines async actions with toast notifications
@@ -771,11 +785,14 @@ function useAuthRedirect(target, condition) { // redirect users when condition i
     }
   };
 
+  // useEffect with dependency array ensures the redirect logic runs only when
+  // the condition or target actually changes, keeping the callback stable and
+  // preventing redundant navigation attempts.
   useEffect(() => { // watch for condition changes to trigger redirect
     if (condition) {
       setLocation(target);
     }
-  }, [condition, target]); // dependencies ensure effect runs when inputs change
+  }, [condition, target]); // stable dependencies so redirect only fires when inputs change
 
   console.log(`useAuthRedirect has run resulting in a final value of undefined`); // exit log
 }


### PR DESCRIPTION
## Summary
- clarify stable closure use in `createDropdownListHook`
- expand mobile hook comment about `react-responsive`
- explain nanoid use in `toast`
- mention Set usage in `useToast`
- add notes for listener and timeout helpers
- document dependency array rationale in `useAuthRedirect`

## Testing
- `npm test` *(fails: react-test-renderer deprecation repeated but tests mostly run)*

------
https://chatgpt.com/codex/tasks/task_b_6850a90b3d90832286fda3704a7f2868