### PR TITLE
Add clarifying comment for test suite export

### DIFF
--- a/tests/internal-helpers.test.js
+++ b/tests/internal-helpers.test.js
@@ -169,5 +169,5 @@ module.exports = function helpersTests({ runTest, renderHook, assert, assertEqua
       assertEqual(e.message, 'undefined', 'Undefined becomes error with message');
     }
   });
-};
+}; // module.exports exposes suite for alternate runners
 


### PR DESCRIPTION
## Summary
- document that tests/internal-helpers.test.js exports its function for use by other runners

## Testing
- `npm test` *(fails: react-test-renderer deprecation lines repeat and runner output stops)*

------
https://chatgpt.com/codex/tasks/task_b_6850a8f546948322b69c2aae6d97d384