### PR TITLE
Update README for dropdown cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Generic React hook for managing dropdown state via a React Query `useQuery` call
 - `user` (Object): User object that triggers data fetch when available
 
 Data loads automatically when the `user` argument becomes truthy and refreshes if a new `toast` function is supplied after mount. The hook skips duplicate fetches on the initial render so a user provided at mount triggers only the React Query request.
-The React Query cache key uses `['dropdown', fetcher.name, user && user._id]` so the key is JSON serializable and predictable across renders.
+The React Query cache key uses `['dropdown', fetcher.name || generatedId, user && user._id]` so the key is JSON serializable and predictable across renders. `generatedId` is a `nanoid` value generated when the fetcher lacks a name. This keeps caching stable even when an anonymous function is used.
 If `user` becomes falsy after data has loaded the hook clears the cached query and returns an empty array so dropdowns reset when logging out.
 
 **Returns:** Object - `{items, isLoading, fetchData}`


### PR DESCRIPTION
## Summary
- clarify how `useDropdownData` generates its React Query cache key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850b5feec108322aea6e30d1e62aa27