### PR TITLE
Update axios client README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Normalizes various error types into consistent Error objects.
 Pre-configured React Query client with optimized defaults for typical CRUD operations.
 
 ### axiosClient
-Pre-configured Axios instance with authentication and JSON handling. Use this instance for all API calls so session cookies and JSON headers are applied consistently.
+Pre-configured Axios instance with authentication and JSON handling. Use this instance for all API calls so session cookies and JSON headers are applied consistently. Its `baseURL` defaults to `window.location.origin` and falls back to `http://localhost:3000` when no browser window exists. The client enforces `Content-Type: application/json` and `withCredentials: true` so cookies are sent with every request. Consumers may attach custom interceptors to this shared instance to extend behavior.
 
 **Returns:** Axios instance for performing HTTP requests
 


### PR DESCRIPTION
## Summary
- document axiosClient defaults in README

## Testing
- `npm test` *(fails: react-test-renderer warnings flood output)*

------
https://chatgpt.com/codex/tasks/task_b_6850ba28cfb88322b53f8ea7c9d3b191