### PR TITLE
docs: note dropdown cache key update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ const { useAsyncAction, useDropdownData, useToast } = require('qreactutils');
 
 ### Recent Updates
 - Enhanced error handling patterns across all hooks
+- Dropdown data now caches by `['dropdown', fetcher.name || generatedId, user._id]` for predictable keys
 - Improved React Query integration with v5 features
 - Comprehensive test suite with over 100 tests passing
 - Advanced async state management with callback patterns


### PR DESCRIPTION
## Summary
- update README to document predictable dropdown cache key

## Testing
- `npm test` *(fails: react-test-renderer deprecation warnings, stops at test 24)*

------
https://chatgpt.com/codex/tasks/task_b_6850ba395ed88322adba6c9d7dcae4b1