### PR TITLE
Update logFunction docs for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ const { executeAsyncWithLogging } = require('qreactutils/lib/utils');
 ### logFunction(name, phase, extra)
 Internal helper for consistent console output across utilities.
 
+Logging is automatically skipped when `NODE_ENV` is set to `production`, so set this environment variable to silence logs in production deployments.
+
 ```javascript
 const { logFunction } = require('qreactutils/lib/utils');
 ```


### PR DESCRIPTION
## Summary
- note how `logFunction` is disabled when `NODE_ENV=production`

## Testing
- `npm test` *(fails: react-test-renderer warnings flood output)*

------
https://chatgpt.com/codex/tasks/task_b_6850d089fd008322bea00d2cd663e39f