### PR TITLE
Update offline dev doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ All tests pass with 100% functional coverage including:
 
 ## Offline Development Mode
 
-The library includes infrastructure for offline development via the `codexRequest` wrapper. Set the environment variable `OFFLINE_MODE=true` to force `codexRequest` to return a mock response. Using `false` or leaving the variable unset runs real network requests. While currently implemented as a pass-through, this enables future enhancement for mock responses during development when backends are unavailable.
+The library includes infrastructure for offline development via the `codexRequest` wrapper. When `OFFLINE_MODE=true`, `codexRequest` returns the `mockResponse` argument or a default `{status: 200, data: null}` so frontend code can proceed without a backend. With the variable unset or `false`, `requestFn` executes normally and the real response is returned.
 
 ## License
 


### PR DESCRIPTION
## Summary
- clarify how `codexRequest` works when offline

## Testing
- `node test.js` *(fails: no test summary)*

------
https://chatgpt.com/codex/tasks/task_b_6850d727218c8322be40202bc7c95df7